### PR TITLE
fix issues with History

### DIFF
--- a/components/SwapHistory/index.tsx
+++ b/components/SwapHistory/index.tsx
@@ -82,6 +82,7 @@ const SwapHistory: FC = () => {
                 swap.timelock &&
                 !isTerminalStatus(swap.status) &&
                 swap.status !== HTLCStatus.TimelockExpired &&
+                swap.status !== HTLCStatus.ManualClaimRequired &&
                 now > swap.timelock * 1000
             ) {
                 updateSwap(hashlock, { status: HTLCStatus.TimelockExpired })

--- a/components/SwapHistory/index.tsx
+++ b/components/SwapHistory/index.tsx
@@ -17,41 +17,32 @@ type DateGroup = {
 }
 
 function buildDateGroups(allEntries: [string, SwapData][]): DateGroup[] {
-    const todayKey = new Date().toLocaleDateString()
-    const todayMidnight = new Date().setHours(0, 0, 0, 0)
-
     const sorted = [...allEntries].sort(([, a], [, b]) => {
-        const aIsTerminal = isTerminalStatus(a.status)
-        const bIsTerminal = isTerminalStatus(b.status)
-
-        // Date bucket (midnight ms): in-progress without date → today, terminal without date → epoch
-        const aBucket = a.createdAt
-            ? new Date(a.createdAt).setHours(0, 0, 0, 0)
-            : aIsTerminal ? 0 : todayMidnight
-        const bBucket = b.createdAt
-            ? new Date(b.createdAt).setHours(0, 0, 0, 0)
-            : bIsTerminal ? 0 : todayMidnight
+        // No createdAt → oldest bucket (0)
+        const aBucket = a.createdAt ? new Date(a.createdAt).setHours(0, 0, 0, 0) : 0
+        const bBucket = b.createdAt ? new Date(b.createdAt).setHours(0, 0, 0, 0) : 0
 
         // Newest date first
         if (bBucket !== aBucket) return bBucket - aBucket
 
-        // Same date: in-progress before terminal
+        // Same date: non-terminal before terminal
+        const aIsTerminal = isTerminalStatus(a.status)
+        const bIsTerminal = isTerminalStatus(b.status)
         if (aIsTerminal !== bIsTerminal) return aIsTerminal ? 1 : -1
 
-        // Same status + same date: newest time first
+        // Same status class + same date: newest time first
         return (b.createdAt ?? 0) - (a.createdAt ?? 0)
     })
 
     const groups: DateGroup[] = []
     for (const entry of sorted) {
         const [, swap] = entry
-        const isTerminal = isTerminalStatus(swap.status)
         const dateKey = swap.createdAt
             ? new Date(swap.createdAt).toLocaleDateString()
-            : isTerminal ? '__older__' : todayKey
+            : '__older__'
         const label = swap.createdAt
             ? getDaysAgoLabel(swap.createdAt)
-            : isTerminal ? 'Older' : getDaysAgoLabel(Date.now())
+            : 'Older'
 
         const last = groups[groups.length - 1]
         if (last && last.dateKey === dateKey) {
@@ -84,7 +75,20 @@ const SwapHistory: FC = () => {
     )
 
     useEffect(() => {
+        const now = Date.now()
         entries.forEach(([hashlock, swap]) => {
+            // Fix stale expired status: if we know the timelock and it has passed, update status
+            if (
+                swap.timelock &&
+                !isTerminalStatus(swap.status) &&
+                swap.status !== HTLCStatus.TimelockExpired &&
+                now > swap.timelock * 1000
+            ) {
+                updateSwap(hashlock, { status: HTLCStatus.TimelockExpired })
+                return
+            }
+
+            // Fetch destTxId for completed swaps that don't have it yet
             if (swap.status !== HTLCStatus.RedeemCompleted || swap.destTxId || !swap.solver) return
             apiClient.GetOrder(swap.solver, hashlock).then(res => {
                 const redeemTx = res?.data?.order?.transactions?.find(t => t.type === HTLCTransaction.HTLCRedeem)?.hash

--- a/context/atomicContext.tsx
+++ b/context/atomicContext.tsx
@@ -174,7 +174,7 @@ export function AtomicProvider({ children }) {
             const stored = useSwapStore.getState().swaps[hashlock]
             const updates: Partial<SwapData> = {}
             if (details.blockTimestamp && !stored?.createdAt) {
-                updates.createdAt = details.blockTimestamp * 1000
+                updates.createdAt = details.blockTimestamp
             }
             if (details.timelock && !stored?.timelock) {
                 updates.timelock = details.timelock

--- a/context/atomicContext.tsx
+++ b/context/atomicContext.tsx
@@ -171,9 +171,15 @@ export function AtomicProvider({ children }) {
     const handleUserLockSuccess = useCallback((details: LockDetails) => {
         if (hashlock) {
             updateHTLCState(hashlock, { sourceDetails: details })
-            if (details.blockTimestamp && !useSwapStore.getState().swaps[hashlock]?.createdAt) {
-                updateSwap(hashlock, { createdAt: details.blockTimestamp })
+            const stored = useSwapStore.getState().swaps[hashlock]
+            const updates: Partial<SwapData> = {}
+            if (details.blockTimestamp && !stored?.createdAt) {
+                updates.createdAt = details.blockTimestamp * 1000
             }
+            if (details.timelock && !stored?.timelock) {
+                updates.timelock = details.timelock
+            }
+            if (Object.keys(updates).length > 0) updateSwap(hashlock, updates)
         }
     }, [hashlock, updateSwap, updateHTLCState])
 

--- a/stores/swapStore.ts
+++ b/stores/swapStore.ts
@@ -20,6 +20,7 @@ export interface SwapData {
     secretRevealed?: boolean
     status?: HTLCStatus
     createdAt?: number
+    timelock?: number
 }
 
 interface SwapStoreState {


### PR DESCRIPTION
This PR fixes how the app handles swaps that expire while the user is away. Previously, if a user closed the app during an in-progress swap and the HTLC timelock passed, the swap would remain stuck in a non-terminal status indefinitely.

The fix has three parts:

Persist the on-chain timelock in the swap store so the app knows when each swap expires
Auto-expire stale swaps on history page load by comparing timelock against Date.now()
Simplify date grouping in the history view — the old workaround that forced in-progress swaps into "Today" is no longer needed
Also fixes a unit mismatch where createdAt was stored in seconds (from blockTimestamp) but consumed as milliseconds.