### PR TITLE
Implement recoverSwap functions, resolves FRONT-900

### DIFF
--- a/apps/app/components/Swap/Atomic/RecoverSwap.tsx
+++ b/apps/app/components/Swap/Atomic/RecoverSwap.tsx
@@ -19,7 +19,7 @@ export default function RecoverSwap({ onRecovered }: RecoverSwapProps) {
     const { recover, loading, error, setError } = useRecoverSwap(selectedNetwork)
     const setActiveHashlock = useSwapStore(s => s.setActiveHashlock)
 
-    const canRecover = isValidTxHash(selectedNetwork?.type?.name, txHash) && selectedNetwork && !loading
+    const canRecover = !!selectedNetwork && txHash.length > 0 && !loading
 
     const handleRecover = async () => {
         if (!canRecover) return
@@ -118,8 +118,3 @@ export default function RecoverSwap({ onRecovered }: RecoverSwapProps) {
     )
 }
 
-function isValidTxHash(networkType: string | undefined, txHash: string): boolean {
-    if (networkType === 'solana') return /^[1-9A-HJ-NP-Za-km-z]{43,88}$/.test(txHash)
-    if (networkType === 'starknet' || networkType === 'aztec') return /^0x[a-fA-F0-9]{1,64}$/.test(txHash)
-    return /^0x[a-fA-F0-9]{64}$/.test(txHash)
-}

--- a/apps/app/components/Swap/Atomic/RecoverSwap.tsx
+++ b/apps/app/components/Swap/Atomic/RecoverSwap.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { Network } from '../../../Models/Network'
-import { useSettingsState } from '../../../context/settings'
-import useRecoverSwap from '../../../hooks/htlc/useRecoverSwap'
-import SubmitButton from '../../buttons/submitButton'
+import { Network } from '@/Models/Network'
+import { useSettingsState } from '@/context/settings'
+import useRecoverSwap from '@/hooks/htlc/useRecoverSwap'
+import SubmitButton from '@/components/buttons/submitButton'
 import Image from 'next/image'
 import { ChevronDown } from 'lucide-react'
 import { useSwapStore } from '@/stores/swapStore'
@@ -19,10 +19,7 @@ export default function RecoverSwap({ onRecovered }: RecoverSwapProps) {
     const { recover, loading, error, setError } = useRecoverSwap(selectedNetwork)
     const setActiveHashlock = useSwapStore(s => s.setActiveHashlock)
 
-    const evmNetworks = networks.filter(n => n.type?.name === 'eip155')
-
-    const isValidTxHash = /^0x[a-fA-F0-9]{64}$/.test(txHash)
-    const canRecover = isValidTxHash && selectedNetwork && !loading
+    const canRecover = isValidTxHash(selectedNetwork?.type?.name, txHash) && selectedNetwork && !loading
 
     const handleRecover = async () => {
         if (!canRecover) return
@@ -65,10 +62,10 @@ export default function RecoverSwap({ onRecovered }: RecoverSwapProps) {
                         <ChevronDown className="h-4 w-4 text-secondary-text" />
                     </button>
                     {showNetworkList && (
-                        <div className="absolute z-20 mt-1 w-full bg-secondary-600 rounded-lg shadow-lg max-h-48 overflow-y-auto">
-                            {evmNetworks.map(network => (
+                        <div className="absolute z-20 mt-1 w-full bg-secondary-600 rounded-lg shadow-lg max-h-64 overflow-y-auto styled-scroll">
+                            {networks.map(network => (
                                 <button
-                                    key={network.chainId}
+                                    key={network.caip2Id}
                                     type="button"
                                     onClick={() => {
                                         setSelectedNetwork(network)
@@ -119,4 +116,10 @@ export default function RecoverSwap({ onRecovered }: RecoverSwapProps) {
             </SubmitButton>
         </div>
     )
+}
+
+function isValidTxHash(networkType: string | undefined, txHash: string): boolean {
+    if (networkType === 'solana') return /^[1-9A-HJ-NP-Za-km-z]{43,88}$/.test(txHash)
+    if (networkType === 'starknet' || networkType === 'aztec') return /^0x[a-fA-F0-9]{1,64}$/.test(txHash)
+    return /^0x[a-fA-F0-9]{64}$/.test(txHash)
 }

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -13,6 +13,7 @@ import useSolverLockPolling from '@/hooks/htlc/useSolverLockPolling';
 import { HTLCStatus, isTerminalStatus } from '@/Models/HTLCStatus';
 import useOrderStreaming from '@/hooks/useOrderStreaming';
 import { useHTLCWriteClient } from '@/hooks/htlc/useHTLCWriteClient';
+import { createHTLCClient } from '@/lib/htlc/createHTLCClient';
 import { useSelectedAccount } from './swapAccounts';
 import useWallet from '@/hooks/useWallet';
 import { Address } from '@/lib/address';
@@ -241,13 +242,23 @@ export function AtomicProvider({ children }) {
         }
     }, [hashlock, updateHTLCState])
 
+    const sourceReadClient = useMemo(() => {
+        if (!source_network) return undefined
+        try { return createHTLCClient(source_network, getEffectiveRpcUrls) } catch { return undefined }
+    }, [source_network, getEffectiveRpcUrls])
+
+    const destinationReadClient = useMemo(() => {
+        if (!destination_network) return undefined
+        try { return createHTLCClient(destination_network, getEffectiveRpcUrls) } catch { return undefined }
+    }, [destination_network, getEffectiveRpcUrls])
+
     useUserLockPolling({
         network: source_network,
         hashlock,
         contractAddress: srcAtomicContract,
         sourceAsset: source_token,
         enabled: !!hashlock && !isTerminal,
-        client: sourceClient,
+        client: sourceReadClient,
         txId: lockTxId as string | undefined,
         onSuccess: handleUserLockSuccess,
     })
@@ -258,7 +269,7 @@ export function AtomicProvider({ children }) {
         contractAddress: destAtomicContract,
         destinationAsset: destination_token,
         enabled: !!hashlock && !isTerminal,
-        client: destinationClient,
+        client: destinationReadClient,
         solverAddress: destinationSolverAddress,
         onSuccess: handleSolverLockSuccess,
         nodeUrls: destination_network ? getEffectiveRpcUrls(destination_network) : [],

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -13,8 +13,10 @@ import useSolverLockPolling from '@/hooks/htlc/useSolverLockPolling';
 import { HTLCStatus, isTerminalStatus } from '@/Models/HTLCStatus';
 import useOrderStreaming from '@/hooks/useOrderStreaming';
 import { useHTLCWriteClient } from '@/hooks/htlc/useHTLCWriteClient';
+import { createHTLCClient } from '@/lib/htlc/createHTLCClient';
 import { useSelectedAccount } from './swapAccounts';
 import useWallet from '@/hooks/useWallet';
+import { Wallet } from '@/Models/WalletProvider';
 import { Address } from '@/lib/address';
 import { useRpcConfigStore } from '@/stores/rpcConfigStore';
 
@@ -189,36 +191,30 @@ export function AtomicProvider({ children }) {
     const { provider: destinationProvider } = useWallet(destination_network, 'autofill')
     const createWriteClient = useHTLCWriteClient()
 
+    const resolveClient = useCallback(async (network: Network, wallet: Wallet | undefined): Promise<IHTLCClient> => {
+        if (!wallet) {
+            if (network.caip2Id.startsWith('aztec:')) throw new Error('Aztec requires a connected wallet')
+            return createHTLCClient(network, getEffectiveRpcUrls)
+        }
+        return createWriteClient(network, wallet)
+    }, [createWriteClient, getEffectiveRpcUrls])
+
     const sourceAccount = useSelectedAccount('from', source_network?.caip2Id)
     const sourceWallet = (sourceAccount?.address && source_network) ? sourceProvider?.connectedWallets?.find(w => Address.equals(w.address, sourceAccount?.address, source_network)) : undefined
     const destinationAccount = useSelectedAccount('to', destination_network?.caip2Id)
     const destinationWallet = (destinationAccount?.address && destination_network) ? destinationProvider?.connectedWallets?.find(w => Address.equals(w.address, destinationAccount?.address, destination_network)) : undefined
 
     useEffect(() => {
-        if (!source_network || !sourceWallet) return
-        (async () => {
-            try {
-                const client = await createWriteClient(source_network, sourceWallet)
-                setSourceClient(client)
-            } catch (e) {
-                console.error('Error creating source HTLC client:', e)
-                setSourceClient(undefined)
-            }
-        })()
-    }, [source_network, sourceWallet, createWriteClient])
+        setSourceClient(undefined)
+        if (!source_network) return
+        resolveClient(source_network, sourceWallet).then(setSourceClient).catch(e => console.error('Error creating source HTLC client:', e))
+    }, [source_network, sourceWallet, resolveClient])
 
     useEffect(() => {
-        if (!destination_network || !destinationWallet) return
-        (async () => {
-            try {
-                const client = await createWriteClient(destination_network, destinationWallet)
-                setDestinationClient(client)
-            } catch (e) {
-                console.error('Error creating destination HTLC client:', e)
-                setDestinationClient(undefined)
-            }
-        })()
-    }, [destination_network, destinationWallet, createWriteClient])
+        setDestinationClient(undefined)
+        if (!destination_network) return
+        resolveClient(destination_network, destinationWallet).then(setDestinationClient).catch(e => console.error('Error creating destination HTLC client:', e))
+    }, [destination_network, destinationWallet, resolveClient])
 
     const handleUserLockSuccess = useCallback((details: LockDetails) => {
         if (hashlock) {

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -192,10 +192,6 @@ export function AtomicProvider({ children }) {
     const createWriteClient = useHTLCWriteClient()
 
     const resolveClient = useCallback(async (network: Network, wallet: Wallet | undefined): Promise<IHTLCClient> => {
-        if (!wallet) {
-            if (network.caip2Id.startsWith('aztec:')) throw new Error('Aztec requires a connected wallet')
-            return createHTLCClient(network, getEffectiveRpcUrls)
-        }
         return createWriteClient(network, wallet)
     }, [createWriteClient, getEffectiveRpcUrls])
 
@@ -207,13 +203,17 @@ export function AtomicProvider({ children }) {
     useEffect(() => {
         setSourceClient(undefined)
         if (!source_network) return
-        resolveClient(source_network, sourceWallet).then(setSourceClient).catch(e => console.error('Error creating source HTLC client:', e))
+        resolveClient(source_network, sourceWallet)
+            .then(setSourceClient)
+            .catch(e => console.error('Error creating source HTLC client:', e))
     }, [source_network, sourceWallet, resolveClient])
 
     useEffect(() => {
         setDestinationClient(undefined)
         if (!destination_network) return
-        resolveClient(destination_network, destinationWallet).then(setDestinationClient).catch(e => console.error('Error creating destination HTLC client:', e))
+        resolveClient(destination_network, destinationWallet)
+            .then(setDestinationClient)
+            .catch(e => console.error('Error creating destination HTLC client:', e))
     }, [destination_network, destinationWallet, resolveClient])
 
     const handleUserLockSuccess = useCallback((details: LockDetails) => {

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -13,10 +13,8 @@ import useSolverLockPolling from '@/hooks/htlc/useSolverLockPolling';
 import { HTLCStatus, isTerminalStatus } from '@/Models/HTLCStatus';
 import useOrderStreaming from '@/hooks/useOrderStreaming';
 import { useHTLCWriteClient } from '@/hooks/htlc/useHTLCWriteClient';
-import { createHTLCClient } from '@/lib/htlc/createHTLCClient';
 import { useSelectedAccount } from './swapAccounts';
 import useWallet from '@/hooks/useWallet';
-import { Wallet } from '@/Models/WalletProvider';
 import { Address } from '@/lib/address';
 import { useRpcConfigStore } from '@/stores/rpcConfigStore';
 
@@ -108,9 +106,7 @@ export function AtomicProvider({ children }) {
     const [manualClaimTxId, setManualClaimTxId] = useState<string | undefined>(undefined);
     const [lightClient, setLightClient] = useState<LightClient | undefined>(undefined);
     const [verifyingByLightClient, setVerifyingByLightClient] = useState(false)
-
-    const [sourceClient, setSourceClient] = useState<IHTLCClient | undefined>(undefined);
-    const [destinationClient, setDestinationClient] = useState<IHTLCClient | undefined>(undefined);
+    const [clients, setClients] = useState<Record<string, IHTLCClient | undefined>>({});
 
     // Restore secretRevealed from persisted swap store on hydration
     useEffect(() => {
@@ -187,13 +183,10 @@ export function AtomicProvider({ children }) {
         if (Object.keys(updates).length > 0) updateSwap(activeHashlock, updates)
     }, [htlcStatus, destinationRedeemTx, activeHashlock, updateSwap])
 
-    const { provider: sourceProvider } = useWallet(source_network, 'withdrawal')
+    const { provider: sourceProvider, providers } = useWallet(source_network, 'withdrawal')
     const { provider: destinationProvider } = useWallet(destination_network, 'autofill')
+    const isProvidersReady = providers.every(p => p.ready)
     const createWriteClient = useHTLCWriteClient()
-
-    const resolveClient = useCallback(async (network: Network, wallet: Wallet | undefined): Promise<IHTLCClient> => {
-        return createWriteClient(network, wallet)
-    }, [createWriteClient, getEffectiveRpcUrls])
 
     const sourceAccount = useSelectedAccount('from', source_network?.caip2Id)
     const sourceWallet = (sourceAccount?.address && source_network) ? sourceProvider?.connectedWallets?.find(w => Address.equals(w.address, sourceAccount?.address, source_network)) : undefined
@@ -201,20 +194,27 @@ export function AtomicProvider({ children }) {
     const destinationWallet = (destinationAccount?.address && destination_network) ? destinationProvider?.connectedWallets?.find(w => Address.equals(w.address, destinationAccount?.address, destination_network)) : undefined
 
     useEffect(() => {
-        setSourceClient(undefined)
         if (!source_network) return
-        resolveClient(source_network, sourceWallet)
-            .then(setSourceClient)
+        setClients(prev => ({ ...prev, [source_network.caip2Id]: undefined }))
+        let cancelled = false
+        createWriteClient(source_network, isProvidersReady ? sourceWallet : undefined)
+            .then(client => { if (!cancelled) setClients(prev => ({ ...prev, [source_network.caip2Id]: client })) })
             .catch(e => console.error('Error creating source HTLC client:', e))
-    }, [source_network, sourceWallet, resolveClient])
+        return () => { cancelled = true }
+    }, [source_network, sourceWallet, isProvidersReady, createWriteClient])
 
     useEffect(() => {
-        setDestinationClient(undefined)
         if (!destination_network) return
-        resolveClient(destination_network, destinationWallet)
-            .then(setDestinationClient)
+        setClients(prev => ({ ...prev, [destination_network.caip2Id]: undefined }))
+        let cancelled = false
+        createWriteClient(destination_network, isProvidersReady ? destinationWallet : undefined)
+            .then(client => { if (!cancelled) setClients(prev => ({ ...prev, [destination_network.caip2Id]: client })) })
             .catch(e => console.error('Error creating destination HTLC client:', e))
-    }, [destination_network, destinationWallet, resolveClient])
+        return () => { cancelled = true }
+    }, [destination_network, destinationWallet, isProvidersReady, createWriteClient])
+
+    const sourceClient = source_network ? clients[source_network.caip2Id] : undefined
+    const destinationClient = destination_network ? clients[destination_network.caip2Id] : undefined
 
     const handleUserLockSuccess = useCallback((details: LockDetails) => {
         if (hashlock) {
@@ -381,7 +381,7 @@ export function AtomicProvider({ children }) {
             error,
             setError,
             setManualClaimTxId,
-            htlcFromApi: htlcFromApi,
+            htlcFromApi,
             lightClient,
             htlcStatus,
             isTimelockExpired,
@@ -410,4 +410,3 @@ export function useAtomicState() {
 
     return data;
 }
-

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -13,7 +13,6 @@ import useSolverLockPolling from '@/hooks/htlc/useSolverLockPolling';
 import { HTLCStatus, isTerminalStatus } from '@/Models/HTLCStatus';
 import useOrderStreaming from '@/hooks/useOrderStreaming';
 import { useHTLCWriteClient } from '@/hooks/htlc/useHTLCWriteClient';
-import { createHTLCClient } from '@/lib/htlc/createHTLCClient';
 import { useSelectedAccount } from './swapAccounts';
 import useWallet from '@/hooks/useWallet';
 import { Address } from '@/lib/address';
@@ -242,23 +241,13 @@ export function AtomicProvider({ children }) {
         }
     }, [hashlock, updateHTLCState])
 
-    const sourceReadClient = useMemo(() => {
-        if (!source_network) return undefined
-        try { return createHTLCClient(source_network, getEffectiveRpcUrls) } catch { return undefined }
-    }, [source_network, getEffectiveRpcUrls])
-
-    const destinationReadClient = useMemo(() => {
-        if (!destination_network) return undefined
-        try { return createHTLCClient(destination_network, getEffectiveRpcUrls) } catch { return undefined }
-    }, [destination_network, getEffectiveRpcUrls])
-
     useUserLockPolling({
         network: source_network,
         hashlock,
         contractAddress: srcAtomicContract,
         sourceAsset: source_token,
         enabled: !!hashlock && !isTerminal,
-        client: sourceReadClient,
+        client: sourceClient,
         txId: lockTxId as string | undefined,
         onSuccess: handleUserLockSuccess,
     })
@@ -269,7 +258,7 @@ export function AtomicProvider({ children }) {
         contractAddress: destAtomicContract,
         destinationAsset: destination_token,
         enabled: !!hashlock && !isTerminal,
-        client: destinationReadClient,
+        client: destinationClient,
         solverAddress: destinationSolverAddress,
         onSuccess: handleSolverLockSuccess,
         nodeUrls: destination_network ? getEffectiveRpcUrls(destination_network) : [],

--- a/apps/app/hooks/htlc/useHTLCWriteClient.ts
+++ b/apps/app/hooks/htlc/useHTLCWriteClient.ts
@@ -78,29 +78,16 @@ export function useHTLCWriteClient() {
                 .find(c => c.connector.name === wallet.id)
                 ?.connector
 
-            const walletClient = await getWalletClient(config, {
-                chainId: chain.id,
-                account: wallet.address as `0x${string}`,
-                connector,
-            })
-            signer = {
-                address: walletClient.account.address,
-                sendTransaction: async (tx) => {
-                    try {
-                        return await walletClient.sendTransaction({
-                            to: tx.to as `0x${string}`,
-                            data: tx.data as `0x${string}`,
-                            value: tx.value,
-                            chain,
-                            account: walletClient.account,
-                        })
-                    } catch (e) {
-                        const isChainMismatch = e instanceof Error && (
-                            e.name === 'ChainMismatchError' ||
-                            (e.cause instanceof Error && e.cause.name === 'ChainMismatchError')
-                        )
-                        if (isChainMismatch && connector?.switchChain) {
-                            await connector.switchChain({ chainId: chain.id })
+            try {
+                const walletClient = await getWalletClient(config, {
+                    chainId: chain.id,
+                    account: wallet.address as `0x${string}`,
+                    connector,
+                })
+                signer = {
+                    address: walletClient.account.address,
+                    sendTransaction: async (tx) => {
+                        try {
                             return await walletClient.sendTransaction({
                                 to: tx.to as `0x${string}`,
                                 data: tx.data as `0x${string}`,
@@ -108,10 +95,26 @@ export function useHTLCWriteClient() {
                                 chain,
                                 account: walletClient.account,
                             })
+                        } catch (e) {
+                            const isChainMismatch = e instanceof Error && (
+                                e.name === 'ChainMismatchError' ||
+                                (e.cause instanceof Error && e.cause.name === 'ChainMismatchError')
+                            )
+                            if (isChainMismatch && connector?.switchChain) {
+                                await connector.switchChain({ chainId: chain.id })
+                                return await walletClient.sendTransaction({
+                                    to: tx.to as `0x${string}`,
+                                    data: tx.data as `0x${string}`,
+                                    value: tx.value,
+                                    chain,
+                                    account: walletClient.account,
+                                })
+                            }
+                            throw e
                         }
-                        throw e
-                    }
-                },
+                    },
+                }
+            } catch {
             }
         }
 

--- a/apps/app/hooks/htlc/useHTLCWriteClient.ts
+++ b/apps/app/hooks/htlc/useHTLCWriteClient.ts
@@ -78,16 +78,29 @@ export function useHTLCWriteClient() {
                 .find(c => c.connector.name === wallet.id)
                 ?.connector
 
-            try {
-                const walletClient = await getWalletClient(config, {
-                    chainId: chain.id,
-                    account: wallet.address as `0x${string}`,
-                    connector,
-                })
-                signer = {
-                    address: walletClient.account.address,
-                    sendTransaction: async (tx) => {
-                        try {
+            const walletClient = await getWalletClient(config, {
+                chainId: chain.id,
+                account: wallet.address as `0x${string}`,
+                connector,
+            })
+            signer = {
+                address: walletClient.account.address,
+                sendTransaction: async (tx) => {
+                    try {
+                        return await walletClient.sendTransaction({
+                            to: tx.to as `0x${string}`,
+                            data: tx.data as `0x${string}`,
+                            value: tx.value,
+                            chain,
+                            account: walletClient.account,
+                        })
+                    } catch (e) {
+                        const isChainMismatch = e instanceof Error && (
+                            e.name === 'ChainMismatchError' ||
+                            (e.cause instanceof Error && e.cause.name === 'ChainMismatchError')
+                        )
+                        if (isChainMismatch && connector?.switchChain) {
+                            await connector.switchChain({ chainId: chain.id })
                             return await walletClient.sendTransaction({
                                 to: tx.to as `0x${string}`,
                                 data: tx.data as `0x${string}`,
@@ -95,26 +108,10 @@ export function useHTLCWriteClient() {
                                 chain,
                                 account: walletClient.account,
                             })
-                        } catch (e) {
-                            const isChainMismatch = e instanceof Error && (
-                                e.name === 'ChainMismatchError' ||
-                                (e.cause instanceof Error && e.cause.name === 'ChainMismatchError')
-                            )
-                            if (isChainMismatch && connector?.switchChain) {
-                                await connector.switchChain({ chainId: chain.id })
-                                return await walletClient.sendTransaction({
-                                    to: tx.to as `0x${string}`,
-                                    data: tx.data as `0x${string}`,
-                                    value: tx.value,
-                                    chain,
-                                    account: walletClient.account,
-                                })
-                            }
-                            throw e
                         }
-                    },
-                }
-            } catch {
+                        throw e
+                    }
+                },
             }
         }
 

--- a/apps/app/hooks/htlc/useRecoverSwap.ts
+++ b/apps/app/hooks/htlc/useRecoverSwap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import formatAmount from '@/lib/formatAmount'
 import { Network } from '@/Models/Network'
 import { SwapData, useSwapStore } from '@/stores/swapStore'
@@ -9,19 +9,15 @@ import { useRpcConfigStore } from '@/stores/rpcConfigStore'
 export default function useRecoverSwap(sourceNetwork: Network | null) {
     const { networks } = useSettingsState()
     const getEffectiveRpcUrls = useRpcConfigStore(s => s.getEffectiveRpcUrls)
-    const client = useMemo(() => {
-        if (!sourceNetwork) return undefined
-        try { return createHTLCClient(sourceNetwork, getEffectiveRpcUrls) }
-        catch { return undefined }
-    }, [sourceNetwork, getEffectiveRpcUrls])
     const recoverSwap = useSwapStore(s => s.recoverSwap)
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
     const recover = useCallback(async (txHash: string): Promise<string> => {
-        if (!client || !sourceNetwork) {
+        if (!sourceNetwork) {
             throw new Error('No client available for this network')
         }
+        const client = createHTLCClient(sourceNetwork, getEffectiveRpcUrls)
 
         setError(null)
         setLoading(true)
@@ -69,7 +65,7 @@ export default function useRecoverSwap(sourceNetwork: Network | null) {
         } finally {
             setLoading(false)
         }
-    }, [client, sourceNetwork, networks, recoverSwap])
+    }, [sourceNetwork, networks, recoverSwap, getEffectiveRpcUrls])
 
     return { recover, loading, error, setError }
 }

--- a/apps/app/hooks/useFee.ts
+++ b/apps/app/hooks/useFee.ts
@@ -136,9 +136,34 @@ export function useQuoteData(formValues: Props | undefined, refreshInterval?: nu
                 setLoading(true)
             }
 
-            // Mock quote for Solana devnet — real API doesn't support it yet
+            // Mock quote for chains not yet supported by the real API
             const urlParams = new URLSearchParams(url.split('?')[1])
-            if (urlParams.get('sourceNetwork')?.startsWith('solana:')) {
+            const sourceNetwork = urlParams.get('sourceNetwork') ?? ''
+            if (sourceNetwork.startsWith('starknet:')) {
+                setKey(url)
+                setLoading(false)
+                const amount = urlParams.get('amount') ?? '1000000000000000000'
+                return {
+                    quote: {
+                        signature: 'mock-starknet-quote',
+                        totalFee: '500000000000000',
+                        receiveAmount: String(BigInt(amount) * 95n / 100n),
+                        sourceSolverAddress: '0x056d5aab86196192bbdb571116b69de5169453eaf3f164300de2616c184fd697',
+                        destinationSolverAddress: '0x0000000000000000000000000000000000000001',
+                        quoteExpirationTimestampInSeconds: Math.floor(Date.now() / 1000) + 3600,
+                        route: {
+                            source: { networkSlug: sourceNetwork, tokenSymbol: 'ETH', tokenContract: urlParams.get('sourceTokenContract') ?? '', tokenDecimals: 18 },
+                            destination: { networkSlug: urlParams.get('destinationNetwork')!, tokenSymbol: 'ETH', tokenContract: urlParams.get('destinationTokenContract') ?? '', tokenDecimals: 18 },
+                            minAmountInSource: '1000000000000000',
+                            maxAmountInSource: '10000000000000000000',
+                        },
+                        timelock: { timelockTimeSpanInSeconds: 3600 },
+                        reward: { amount: '0', rewardTimelockTimeSpanInSeconds: 3600, rewardToken: '', rewardRecipientAddress: '' },
+                    },
+                    solverId: 'mock-solver',
+                }
+            }
+            if (sourceNetwork.startsWith('solana:')) {
                 setKey(url)
                 setLoading(false)
                 const amount = urlParams.get('amount') ?? '1000000000'
@@ -151,7 +176,7 @@ export function useQuoteData(formValues: Props | undefined, refreshInterval?: nu
                         destinationSolverAddress: '0x0000000000000000000000000000000000000001',
                         quoteExpirationTimestampInSeconds: Math.floor(Date.now() / 1000) + 3600,
                         route: {
-                            source: { networkSlug: urlParams.get('sourceNetwork')!, tokenSymbol: 'SOL', tokenContract: '', tokenDecimals: 9 },
+                            source: { networkSlug: sourceNetwork, tokenSymbol: 'SOL', tokenContract: '', tokenDecimals: 9 },
                             destination: { networkSlug: urlParams.get('destinationNetwork')!, tokenSymbol: 'ETH', tokenContract: '', tokenDecimals: 18 },
                             minAmountInSource: '10000000',
                             maxAmountInSource: '10000000000000',

--- a/apps/app/lib/NetworkSettings.ts
+++ b/apps/app/lib/NetworkSettings.ts
@@ -123,6 +123,10 @@ export default class NetworkSettings {
             TransactionExplorerTemplate: 'https://explorer.solana.com/tx/{0}?cluster=devnet',
             AccountExplorerTemplate: 'https://explorer.solana.com/address/{0}?cluster=devnet',
         };
+        NetworkSettings.KnownSettings[KnownInternalNames.Networks.StarkNetSepolia] = {
+            TransactionExplorerTemplate: 'https://sepolia.starkscan.co/tx/{0}',
+            AccountExplorerTemplate: 'https://sepolia.starkscan.co/contract/{0}',
+        };
 
 
         for (var k in NetworkSettings.KnownSettings) {

--- a/packages/blockchains/IntegrationRules.md
+++ b/packages/blockchains/IntegrationRules.md
@@ -259,7 +259,13 @@ Key points:
 
 ### recoverSwap
 
-Fetch transaction + receipt, parse the `UserLocked` event from logs, return `RecoveredSwapData`. If not applicable, throw.
+**Must validate the `txHash` format at the top of the function before making any RPC calls.** Throw `'Invalid transaction hash format'` if it doesn't match. Each chain has its own expected format:
+
+- EVM: `/^0x[a-fA-F0-9]{64}$/`
+- Starknet / Aztec: `/^0x[a-fA-F0-9]{1,64}$/`
+- Solana: `/^[1-9A-HJ-NP-Za-km-z]{43,88}$/`
+
+Then fetch transaction + receipt, parse the `UserLocked` event from logs, return `RecoveredSwapData`. If the event is not found, throw.
 
 ---
 
@@ -431,6 +437,7 @@ const ZERO_ADDRESS = '0x000...'     // Chain's empty/zero address representation
 - [ ] Implement `{Chain}HTLCClient extends HTLCClient` in `client.ts`
 - [ ] Follow function ordering: writes → reads → private helpers
 - [ ] Implement count-then-loop pattern in `_getSolverLockDetails` (1-indexed, single-node version)
+- [ ] Validate `txHash` format at the top of `recoverSwap` before any RPC calls
 - [ ] Define `{Chain}WalletLike` minimal interface in `login/wallet-sign.ts`
 - [ ] Implement key derivation in `login/wallet-sign.ts` using `deriveKeyMaterial` + `IDENTITY_SALT`
 - [ ] Create idempotent `register{Chain}Sdk()` in `index.ts` — pass config directly (no `as` casts)

--- a/packages/blockchains/aztec/src/client.ts
+++ b/packages/blockchains/aztec/src/client.ts
@@ -289,8 +289,48 @@ export class AztecHTLCClient extends HTLCClient {
         return null
     }
 
-    async recoverSwap(_txHash: string): Promise<RecoveredSwapData> {
-        throw new Error('recoverSwap is not supported for Aztec')
+    async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        const node = this.getNode()
+        const { logs } = await node.getPublicLogs({
+            txHash: TxHash.fromString(txHash),
+        })
+
+        if (!logs.length) throw new Error('Transaction not found')
+
+        const eventDef = TrainContract.events.UserLocked
+
+        for (const log of logs) {
+            const emittedFields = log.log.getEmittedFields()
+            if (emittedFields.length === 0) continue
+
+            const selectorField = emittedFields[emittedFields.length - 1]
+            const selector = EventSelector.fromField(selectorField)
+            if (selector.toString() !== eventDef.eventSelector.toString()) continue
+
+            const decoded = decodeFromAbi(
+                [eventDef.abiType],
+                log.log.fields,
+            ) as Record<string, any>
+
+            const bytesToString = (bytes: (bigint | number)[]) =>
+                Buffer.from(bytes.map(Number)).toString('utf8').replace(/\0/g, '').trim()
+
+            return {
+                hashlock: bytesToHex(Array.from(decoded.hashlock).map(Number)),
+                sender: decoded.sender.toString(),
+                recipient: decoded.recipient.toString(),
+                srcChain: bytesToString(decoded.src_chain),
+                dstChain: bytesToString(decoded.dst_chain),
+                token: decoded.token.toString(),
+                amount: BigInt(decoded.amount),
+                dstAddress: bytesToString(decoded.dst_address),
+                dstAmount: BigInt(decoded.dst_amount),
+                dstToken: bytesToString(decoded.dst_token),
+                srcContract: log.log.contractAddress.toString(),
+            }
+        }
+
+        throw new Error('This transaction does not contain a swap lock')
     }
 
     private parseSecret(rawSecret: unknown): bigint | undefined {

--- a/packages/blockchains/aztec/src/client.ts
+++ b/packages/blockchains/aztec/src/client.ts
@@ -290,6 +290,9 @@ export class AztecHTLCClient extends HTLCClient {
     }
 
     async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        if (!/^0x[a-fA-F0-9]{1,64}$/.test(txHash))
+            throw new Error('Invalid transaction hash format')
+
         const node = this.getNode()
         const { logs } = await node.getPublicLogs({
             txHash: TxHash.fromString(txHash),

--- a/packages/blockchains/evm/src/client.ts
+++ b/packages/blockchains/evm/src/client.ts
@@ -221,6 +221,9 @@ export class EvmHTLCClient extends HTLCClient {
     }
 
     async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        if (!/^0x[a-fA-F0-9]{64}$/.test(txHash))
+            throw new Error('Invalid transaction hash format')
+
         const [receipt, tx] = await Promise.all([
             this.rpc.getTransactionReceipt(txHash),
             this.rpc.getTransaction(txHash),

--- a/packages/blockchains/solana/src/client.ts
+++ b/packages/blockchains/solana/src/client.ts
@@ -283,6 +283,9 @@ export class SolanaHTLCClient extends HTLCClient {
     }
 
     async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        if (!/^[1-9A-HJ-NP-Za-km-z]{43,88}$/.test(txHash))
+            throw new Error('Invalid transaction hash format')
+
         let tx = await this.connection.getTransaction(txHash, {
             commitment: 'confirmed',
             maxSupportedTransactionVersion: 0,

--- a/packages/blockchains/solana/src/client.ts
+++ b/packages/blockchains/solana/src/client.ts
@@ -1,4 +1,4 @@
-import { AnchorProvider, BN, Program, Wallet } from '@coral-xyz/anchor'
+import { AnchorProvider, BN, BorshCoder, EventParser, Program, Wallet } from '@coral-xyz/anchor'
 import { Connection, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js'
 import {
     HTLCClient,
@@ -159,8 +159,14 @@ export class SolanaHTLCClient extends HTLCClient {
 
         if (!contractAddress) throw new Error('No contract address')
 
+        let program: ReturnType<typeof this.buildProgram>
+        try {
+            program = this.buildProgram(contractAddress)
+        } catch {
+            return null
+        }
+
         const hashlockBuffer = Buffer.from(id.replace('0x', ''), 'hex')
-        const program = this.buildProgram(contractAddress)
 
         const [userLockPda] = PublicKey.findProgramAddressSync(
             [Buffer.from("user_lock"), hashlockBuffer],
@@ -276,8 +282,65 @@ export class SolanaHTLCClient extends HTLCClient {
         return null
     }
 
-    async recoverSwap(_txHash: string): Promise<RecoveredSwapData> {
-        throw new Error('recoverSwap is not supported for Solana')
+    async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        let tx = await this.connection.getTransaction(txHash, {
+            commitment: 'confirmed',
+            maxSupportedTransactionVersion: 0,
+        })
+        if (!tx || !tx.meta?.logMessages?.length) {
+            tx = await this.connection.getTransaction(txHash, {
+                commitment: 'finalized',
+                maxSupportedTransactionVersion: 0,
+            })
+        }
+        if (!tx) throw new Error('Transaction not found')
+
+        const logs = tx.meta?.logMessages ?? []
+
+        const invokeRegex = /^Program (\S+) invoke \[\d+\]$/
+        const programIds = [...new Set(
+            logs.map(l => l.match(invokeRegex)?.[1]).filter((id): id is string => !!id)
+        )]
+
+        let userLocked: { name: string; data: Record<string, unknown> } | undefined
+        let srcContract: string | undefined
+
+        for (const pid of programIds) {
+            try {
+                const parser = new EventParser(new PublicKey(pid), new BorshCoder(TrainHtlc(pid)))
+                for (const event of parser.parseLogs(logs)) {
+                    if (event.name.toLowerCase() === 'userlocked') {
+                        userLocked = { name: event.name, data: event.data as Record<string, unknown> }
+                        srcContract = pid
+                        break
+                    }
+                }
+                if (userLocked) break
+            } catch {
+                // Not a TrainHtlc program — skip
+            }
+        }
+
+        if (!userLocked || !srcContract) {
+            throw new Error('This transaction does not contain a swap lock')
+        }
+
+        const data = userLocked.data as Record<string, any>
+        const hashlock = '0x' + Buffer.from(Array.from(data.hashlock as number[])).toString('hex')
+
+        return {
+            hashlock,
+            sender: (data.sender as PublicKey).toBase58(),
+            recipient: (data.recipient as PublicKey).toBase58(),
+            srcChain: data.src_chain as string,
+            dstChain: data.dst_chain as string,
+            token: (data.token_mint as PublicKey).toBase58(),
+            amount: BigInt((data.amount as BN).toString()),
+            dstAddress: data.dst_address as string,
+            dstAmount: BigInt((data.dst_amount as BN).toString()),
+            dstToken: data.dst_token as string,
+            srcContract,
+        }
     }
 
     // ── Private Helpers ─────────────────────────────────────────────────
@@ -348,7 +411,7 @@ export class SolanaHTLCClient extends HTLCClient {
                 const eventHashlock = '0x' + Buffer.from(hashlockBytes).toString('hex')
                 if (eventHashlock.toLowerCase() !== `0x${id.replace('0x', '')}`.toLowerCase()) continue
 
-                const userDataBytes: number[] = Array.from((event.data as Record<string, unknown>).userData as Buffer ?? [])
+                const userDataBytes: number[] = Array.from((event.data as Record<string, unknown>).user_data as Buffer ?? [])
                 const userData = userDataBytes.length > 0
                     ? Buffer.from(userDataBytes).toString('utf8').replace(/\0/g, '').trim() || undefined
                     : undefined

--- a/packages/blockchains/starknet/src/client.ts
+++ b/packages/blockchains/starknet/src/client.ts
@@ -181,6 +181,9 @@ export class StarknetHTLCClient extends HTLCClient {
     }
 
     async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        if (!/^0x[a-fA-F0-9]{1,64}$/.test(txHash))
+            throw new Error('Invalid transaction hash format')
+
         const receipt = await this.provider.getTransactionReceipt(txHash)
         if (!receipt || !('events' in receipt)) throw new Error('Transaction not found')
 

--- a/packages/blockchains/starknet/src/client.ts
+++ b/packages/blockchains/starknet/src/client.ts
@@ -1,4 +1,4 @@
-import { cairo, Contract, ProviderOrAccount, RpcProvider, type Call } from 'starknet'
+import { cairo, Contract, hash, ProviderOrAccount, RpcProvider, type Call } from 'starknet'
 import {
     UserLockParams,
     LockParams,
@@ -180,8 +180,40 @@ export class StarknetHTLCClient extends HTLCClient {
         return null
     }
 
-    async recoverSwap(_txHash: string): Promise<RecoveredSwapData> {
-        throw new Error('recoverSwap is not supported for Starknet')
+    async recoverSwap(txHash: string): Promise<RecoveredSwapData> {
+        const receipt = await this.provider.getTransactionReceipt(txHash)
+        if (!receipt || !('events' in receipt)) throw new Error('Transaction not found')
+
+        const userLockedSelector = hash.getSelectorFromName('UserLocked')
+        const rawEvent = receipt.events.find(e => e.keys.includes(userLockedSelector))
+        if (!rawEvent) throw new Error('This transaction does not contain a swap lock')
+
+        const srcContract = rawEvent.from_address
+
+        const contract = this.createContract(srcContract, this.provider)
+        const parsed = contract.parseEvents(receipt)
+
+        const userLockedEntry = parsed.find(
+            ev => Object.keys(ev).some(k => k.includes('UserLocked'))
+        )
+        if (!userLockedEntry) throw new Error('Failed to decode UserLocked event')
+
+        const eventKey = Object.keys(userLockedEntry).find(k => k.includes('UserLocked'))!
+        const event = userLockedEntry[eventKey] as Record<string, any>
+
+        return {
+            hashlock: '0x' + BigInt(event.hashlock).toString(16),
+            sender: '0x' + BigInt(event.sender).toString(16),
+            recipient: '0x' + BigInt(event.recipient).toString(16),
+            srcChain: event.src_chain as string,
+            dstChain: event.dst_chain as string,
+            token: '0x' + BigInt(event.token).toString(16),
+            amount: BigInt(event.amount),
+            dstAddress: event.dst_address as string,
+            dstAmount: BigInt(event.dst_amount),
+            dstToken: event.dst_token as string,
+            srcContract,
+        }
     }
 
     // ── Private Helpers ────────────────────────────────────────────────

--- a/packages/blockchains/starknet/src/client.ts
+++ b/packages/blockchains/starknet/src/client.ts
@@ -1,4 +1,4 @@
-import { cairo, Contract, hash, ProviderOrAccount, RpcProvider, type Call } from 'starknet'
+import { cairo, Contract, hash, num, addAddressPadding, ProviderOrAccount, RpcProvider, type Call } from 'starknet'
 import {
     UserLockParams,
     LockParams,
@@ -201,17 +201,20 @@ export class StarknetHTLCClient extends HTLCClient {
         const eventKey = Object.keys(userLockedEntry).find(k => k.includes('UserLocked'))!
         const event = userLockedEntry[eventKey] as Record<string, any>
 
+        const rawDstToken = event.dst_token as string
+        const dstToken = !rawDstToken || /^[\u0000]+$/.test(rawDstToken) ? '0x0000000000000000000000000000000000000000' : rawDstToken
+
         return {
-            hashlock: '0x' + BigInt(event.hashlock).toString(16),
-            sender: '0x' + BigInt(event.sender).toString(16),
-            recipient: '0x' + BigInt(event.recipient).toString(16),
+            hashlock: addAddressPadding(num.toHex(event.hashlock)),
+            sender: addAddressPadding(num.toHex(event.sender)),
+            recipient: addAddressPadding(num.toHex(event.recipient)),
             srcChain: event.src_chain as string,
             dstChain: event.dst_chain as string,
-            token: '0x' + BigInt(event.token).toString(16),
+            token: addAddressPadding(num.toHex(event.token)),
             amount: BigInt(event.amount),
             dstAddress: event.dst_address as string,
             dstAmount: BigInt(event.dst_amount),
-            dstToken: event.dst_token as string,
+            dstToken,
             srcContract,
         }
     }


### PR DESCRIPTION
Implement recoverSwap for Starknet and Aztec; fix Solana recovery bugs

Starknet: implement recoverSwap by fetching the transaction receipt,
finding the UserLocked event by selector, and decoding it via
contract.parseEvents.

Aztec: implement recoverSwap by fetching public logs for the tx hash,
matching the UserLocked event selector, and decoding fields from ABI.

Solana: fix recoverSwap using Anchor EventParser for correct program
attribution (previously attributed UserLocked to ComputeBudget program);
fix all decoded field accesses to snake_case (Anchor 0.30 preserves
field names as-is); add null-guard in getUserLockDetails to handle
non-Base58 contract addresses without throwing.

Add Starknet Sepolia to NetworkSettings with explorer URL templates,
and add a mock quote for Starknet source chains in useFee.