### PR TITLE
Fix: prevent auto-scroll when hovering partially visible items in navigatable list

### DIFF
--- a/apps/app/components/NavigatableList/NavigatableItem.tsx
+++ b/apps/app/components/NavigatableList/NavigatableItem.tsx
@@ -34,7 +34,7 @@ const NavigatableItemInner = forwardRef<HTMLDivElement, NavigatableItemProps>(({
     focusedClassName,
     tabIndex = 0
 }, ref) => {
-    const { focusedIndex } = useNavigatableListState();
+    const { focusedIndex, isKeyboardNavigating } = useNavigatableListState();
     const registrationContext = useContext(NavigatableRegistrationContext);
 
     const isChild = parentIndex !== undefined;
@@ -90,7 +90,7 @@ const NavigatableItemInner = forwardRef<HTMLDivElement, NavigatableItemProps>(({
     const dataNavIndex = focusedIndexToString(effectiveIndex);
 
     // Use shared hooks
-    const itemRef = useScrollIntoView(isFocused);
+    const itemRef = useScrollIntoView(isFocused, isKeyboardNavigating);
     const handleKeyDownInternal = useSpaceKeyClick(onClick, onKeyDown);
     const handleMouseEnterInternal = useHoverHandler(effectiveIndex, onMouseEnter);
     const handleFocusInternal = useFocusHandler();

--- a/apps/app/components/NavigatableList/hooks.ts
+++ b/apps/app/components/NavigatableList/hooks.ts
@@ -4,14 +4,14 @@ import { useNavigatableListUpdate, FocusedIndex } from './context';
 /**
  * Hook to handle scrolling element into view when focused
  */
-export function useScrollIntoView(isFocused: boolean) {
+export function useScrollIntoView(isFocused: boolean, isKeyboardNavigating: boolean) {
     const elementRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (isFocused && elementRef.current) {
+        if (isFocused && isKeyboardNavigating && elementRef.current) {
             elementRef.current.scrollIntoView({ block: 'nearest', behavior: 'auto' });
         }
-    }, [isFocused]);
+    }, [isFocused, isKeyboardNavigating]);
 
     return elementRef;
 }


### PR DESCRIPTION
Gate scrollIntoView behind isKeyboardNavigating so that mouse hover on edge-cropped items no longer triggers unwanted scroll jumps.