### PR TITLE
Refactor error handling with typed error codes in SDK and app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,16 @@ Key files:
 - Solana: @solana/web3.js + wallet-adapter
 - TON: @ton/ton + @tonconnect/ui-react
 
+### Error Handling
+Two-layer typed error system — no string matching in consumers:
+- **SDK** (`packages/sdk/src/errors.ts`): `TrainError` class + `TrainErrorCode` enum for protocol-level errors (API, consensus, passkey, registry, validation)
+- **App** (`apps/app/lib/errors.ts`): `AppError` class + `AppErrorCode` enum for UI-level errors (user rejection, insufficient funds, chain mismatch, etc.)
+- `ErrorCode = TrainErrorCode | AppErrorCode` — unified type, no duplication between layers
+- `classifyError(raw)` in `apps/app/lib/errors.ts` is the **single place** that does string matching on raw errors. All consumers switch on `.code`
+- `isActionDisabled(code)` determines if retry is possible (replaces the old `disableButton` flag)
+- Blockchain packages throw plain `Error`s — no custom types imposed on integrators
+- `atomicContext` error state is `AppError | undefined`, not raw strings
+
 ## Key Conventions
 
 - Code uses legacy "commit" naming (`CommitStatus`, `commitId`) — these refer to **locks**, not a separate commit step

--- a/apps/app/components/SecretDerivation/LoginModal/index.tsx
+++ b/apps/app/components/SecretDerivation/LoginModal/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Loader2, ChevronLeft, CircleX } from 'lucide-react';
 import VaulModal from '@/components/Modal/vaulModal';
 import { useSecretDerivation } from '@/context/secretDerivationContext';
-import { mapPasskeyError } from '@/lib/htlc/secretDerivation/passkeyService';
+import { classifyError } from '@/lib/errors';
 import { PasskeyChoice } from './PasskeyChoice';
 import { Wallet } from '@/Models/WalletProvider';
 import { useSteps } from '@/hooks/useSteps';
@@ -13,12 +13,6 @@ import WalletSelect from './SelectWallet';
 import { usePasskeyCredentialIds } from '@/stores/secretDerivationStore';
 
 type LoginStep = 'pick' | 'passkey_recovery' | 'wallet_select' | 'signing';
-
-const getErrorMessage = (error: unknown, fallback: string): string => {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  return fallback;
-};
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -59,8 +53,7 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
       }
       closeAndReset();
     } catch (e) {
-      const message = mapPasskeyError(e);
-      setPasskeyError(message);
+      setPasskeyError(classifyError(e).message);
       goToStep('passkey_recovery', 'back');
     }
   };
@@ -73,8 +66,7 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
       await loginWithWallet(wallet);
       closeAndReset();
     } catch (e) {
-      const message = getErrorMessage(e, 'Wallet login failed');
-      setSigningError(message);
+      setSigningError(classifyError(e).message);
     }
   };
 

--- a/apps/app/components/Swap/AtomicChat/Actions/ManualClaim.tsx
+++ b/apps/app/components/Swap/AtomicChat/Actions/ManualClaim.tsx
@@ -3,6 +3,7 @@ import { useAtomicState } from "@/context/atomicContext";
 import useWallet from "@/hooks/useWallet";
 import { WalletActionButton } from "../../buttons";
 import posthog from "posthog-js";
+import { classifyError } from "@/lib/errors";
 import { SwapViewType } from ".";
 
 export const ManualClaimAction: FC<{ type: SwapViewType }> = ({ type }) => {
@@ -56,7 +57,7 @@ export const ManualClaimAction: FC<{ type: SwapViewType }> = ({ type }) => {
                 destinationNetwork: destination_network.caip2Id,
             });
         } catch (e: any) {
-            setError({ message: e.details || e.message });
+            setError(classifyError(e));
         }
     };
 

--- a/apps/app/components/Swap/AtomicChat/Actions/UserActions.tsx
+++ b/apps/app/components/Swap/AtomicChat/Actions/UserActions.tsx
@@ -3,6 +3,7 @@ import useWallet from "@/hooks/useWallet";
 import { useAtomicState } from "@/context/atomicContext";
 import { WalletActionButton } from "../../buttons";
 import posthog from "posthog-js";
+import { classifyError } from "@/lib/errors";
 import { LockStatus } from "@/Models/phtlc/PHTLC";
 import { SwapQuote } from "@/lib/trainApiClient";
 import { useSwapStore } from "@/stores/swapStore";
@@ -79,7 +80,7 @@ export const UserLockAction: FC<UserCommitActionProps> = ({ quote, type }) => {
         }
         catch (e) {
             console.error('[UserLock] failed', e?.message ?? String(e), ...(e?.logs ? [e.logs] : []))
-            setError({ message: e?.details || e?.message || e?.code || e?.name || 'Unknown error' })
+            setError(classifyError(e))
         }
     }
 
@@ -161,7 +162,7 @@ export const UserRefundAction: FC<{ type: SwapViewType }> = ({ type }) => {
             }
         }
         catch (e) {
-            setError({ message: e.details || e.message })
+            setError(classifyError(e))
         }
     }
 

--- a/apps/app/components/Swap/AtomicChat/Actions/index.tsx
+++ b/apps/app/components/Swap/AtomicChat/Actions/index.tsx
@@ -21,6 +21,8 @@ import { HTLCStatus } from "@/Models/HTLCStatus";
 import { useLoginIdentityMismatch } from "@/hooks/useLoginIdentityMismatch";
 import { useSwapStore } from "@/stores/swapStore";
 import { useShallow } from "zustand/react/shallow";
+import { AppError, AppErrorCode, isActionDisabled } from "@/lib/errors";
+import { TrainErrorCode } from "@train-protocol/sdk";
 
 export type SwapViewType = "widget" | "contained"
 
@@ -34,12 +36,11 @@ export const Actions: FC<ActionsProps> = ({ quote, type }) => {
 
     return (
         <>
-            {error && <TransactionMessage error={error.message} disableButton={error.disableButton} />}
+            {error && <TransactionMessage error={error} />}
             <DestinationWalletWrapper>
                 <ResolveAction
                     commitStatus={commitStatus}
-                    disableButton={error?.disableButton}
-                    error={error?.message}
+                    error={error}
                     quote={quote}
                     type={type}
                 />
@@ -50,16 +51,15 @@ export const Actions: FC<ActionsProps> = ({ quote, type }) => {
 
 type ResolveActionProps = {
     commitStatus: HTLCStatus
-    disableButton?: boolean
-    error: string | undefined
+    error: AppError | undefined
     quote?: SwapQuote
     type: SwapViewType
 }
 
-const ResolveAction: FC<ResolveActionProps> = ({ commitStatus, disableButton, error, quote, type }) => {
+const ResolveAction: FC<ResolveActionProps> = ({ commitStatus, error, quote, type }) => {
     const { setError } = useAtomicState()
 
-    if (error && !disableButton) {
+    if (error && !isActionDisabled(error.code)) {
         return (
             <SubmitButton type="button" onClick={() => setError(undefined)}>
                 Try again
@@ -183,36 +183,34 @@ const TerminalActions: FC<{ variant: 'success' | 'refund'; type: SwapViewType }>
     )
 }
 
-const TransactionMessage: FC<{ error: string | undefined, disableButton?: boolean }> = ({ error, disableButton }) => {
-    if (disableButton && error) {
+const TransactionMessage: FC<{ error: AppError | undefined }> = ({ error }) => {
+    if (!error) return <></>
+    if (isActionDisabled(error.code)) {
         return (
             <WalletMessage
                 status="error"
                 header="Something went wrong"
-                details={error}
+                details={error.message}
             />
         )
     }
-    if (error === "An error occurred (USER_REFUSED_OP)" || error === "Execute failed" || error?.toLowerCase()?.includes('denied') || error?.toLowerCase()?.includes('user rejected')) {
-        return <TransactionMessages.TransactionRejectedMessage />
+    switch (error.code) {
+        case AppErrorCode.USER_REJECTED:
+            return <TransactionMessages.TransactionRejectedMessage />
+        case AppErrorCode.INSUFFICIENT_FUNDS:
+            return <TransactionMessages.InsufficientFundsMessage />
+        case AppErrorCode.TIMELOCK_EXPIRED:
+            return (
+                <WalletMessage
+                    status="error"
+                    header="Timelock expired"
+                    details="Unfortunately the time lock was expired, continuing the transaction is not recommended, cancel & refund to receive your assets back."
+                />
+            )
+        case TrainErrorCode.API_REQUEST_FAILED:
+        case TrainErrorCode.API_CLIENT_MISCONFIGURED:
+            return <WalletMessage status="error" header="API error" details="Something went wrong while communicating with the server. Please try again." />
+        default:
+            return <TransactionMessages.UexpectedErrorMessage message={error.message} />
     }
-    if (error?.includes('insufficient funds')) {
-        return <TransactionMessages.InsufficientFundsMessage />
-    }
-    if (error === "Timelock expired") {
-        return (
-            <WalletMessage
-                status="error"
-                header="Timelock expired"
-                details="Unfortunately the time lock was expired, continuing the transaction is not recommended, cancel & refund to receive your assets back."
-            />
-        )
-    }
-    if (error === 'TrainApiError') {
-        return <WalletMessage status="error" header="API error" details="Something went wrong while communicating with the server. Please try again." />
-    }
-    if (error) {
-        return <TransactionMessages.UexpectedErrorMessage message={error} />
-    }
-    return <></>
 }

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/index.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/index.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect } from "react";
 import { useAtomicState } from "@/context/atomicContext";
+import { AppError, AppErrorCode } from "@/lib/errors";
 import Summary from "./Summary";
 import { usePulsatingCircles } from "@/stores/pulsatingCirclesStore";
 import { SwapQuote } from "@/lib/trainApiClient";
@@ -48,7 +49,7 @@ const AtomicContent: FC<AtomicContentProps> = ({ quote, isQuoteLoading = false }
         const lcHash = destinationDetailsByLightClient?.data?.hashlock
         const solverHash = solverLockDetails?.hashlock
         if (lcHash && solverHash && lcHash !== solverHash) {
-            setError({ message: 'Hashlock mismatch, please wait for refund.', disableButton: true })
+            setError(new AppError(AppErrorCode.HASHLOCK_MISMATCH, 'Hashlock mismatch, please wait for refund.'))
         }
     }, [solverLockDetails, destinationDetailsByLightClient]);
 

--- a/apps/app/components/WalletModal/ConnectorsList.tsx
+++ b/apps/app/components/WalletModal/ConnectorsList.tsx
@@ -8,6 +8,7 @@ import { usePersistedState } from "@/hooks/usePersistedState";
 import { useConnectors } from "@/hooks/useConnectors";
 import { SearchComponent } from "@/components/Input/Search";
 import CircularLoader from "@/components/Icons/CircularLoader";
+import { classifyError, AppErrorCode } from "@/lib/errors";
 import { MultichainConnectorPicker } from "./MultichainConnectorPicker";
 import { ProviderPicker } from "./ProviderPicker";
 import { InstalledExtensionNotFound } from "./InstalledExtensionNotFound";
@@ -90,11 +91,12 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
             setSelectedConnector(undefined)
         } catch (e) {
             console.log(e)
-            if (e?.message?.toLowerCase().includes('rejected') || e?.details?.toLowerCase().includes('rejected')) {
+            const classified = classifyError(e)
+            if (classified.code === AppErrorCode.USER_REJECTED) {
                 setConnectionError("You've declined the wallet connection request")
             }
             else {
-                setConnectionError(e.message || e.details || 'Something went wrong')
+                setConnectionError(classified.message)
             }
         }
     }

--- a/apps/app/context/atomicContext.tsx
+++ b/apps/app/context/atomicContext.tsx
@@ -4,7 +4,8 @@ import { useSettingsState } from './settings';
 import { LockDetails, LockStatus } from '../Models/phtlc/PHTLC';
 import { Network, Token } from '@/Models/Network';
 import { Wallet } from '@/Models/WalletProvider';
-import { HTLCFromApi, HTLCTransaction, resolveHTLCStatus, IHTLCClient } from '@train-protocol/sdk';
+import { HTLCFromApi, HTLCTransaction, resolveHTLCStatus, IHTLCClient, TrainErrorCode } from '@train-protocol/sdk';
+import { AppError, AppErrorCode } from '@/lib/errors';
 import { SwapData, useSwapStore } from '@/stores/swapStore';
 import { useShallow } from 'zustand/react/shallow';
 import { resolvePersistantQueryParams } from '@/helpers/querryHelper';
@@ -41,8 +42,8 @@ type DataContextType = HTLCState & {
     destAtomicContract?: string,
     sourceClient?: IHTLCClient,
     destinationClient?: IHTLCClient,
-    error?: { message: string, disableButton?: boolean },
-    setError: (error: { message: string, disableButton?: boolean } | undefined) => void;
+    error?: AppError,
+    setError: (error: AppError | undefined) => void;
     setManualClaimTxId: (txId: string | undefined) => void;
     onUserLock: (hashlock: string, txId: string) => void;
     updateHTLC: (field: keyof HTLCState, value: any) => void;
@@ -104,7 +105,7 @@ export function AtomicProvider({ children }) {
     const destinationSolverAddress = currentSwap?.destinationSolverAddress
 
     const [htlcStates, setHtlcStates] = useState<CommitStatesDict>({});
-    const [error, setError] = useState<{ message: string, disableButton?: boolean } | undefined>(undefined);
+    const [error, setError] = useState<AppError | undefined>(undefined);
     const [manualClaimTxId, setManualClaimTxId] = useState<string | undefined>(undefined);
 
     // Restore secretRevealed from persisted swap store on hydration
@@ -163,7 +164,7 @@ export function AtomicProvider({ children }) {
             if (hashlock) updateHTLCState(hashlock, { htlcFromApi: order })
         },
         onFailed: () => {
-            setError({ message: 'Please wait for the timelock to expire, then refund to receive your assets back.', disableButton: true })
+            setError(new AppError(AppErrorCode.SOLVER_FAILED, 'Please wait for the timelock to expire, then refund to receive your assets back.'))
         },
     })
 
@@ -247,9 +248,7 @@ export function AtomicProvider({ children }) {
     )
 
     const handleConsensusFailed = useCallback(() => {
-        setError({
-            message: 'RPC node verification failed — nodes returned conflicting data. Your funds are safe and will be automatically refundable after the timelock expires.',
-        })
+        setError(new AppError(TrainErrorCode.CONSENSUS_MISMATCH, 'RPC node verification failed — nodes returned conflicting data. Your funds are safe and will be automatically refundable after the timelock expires.'))
     }, [setError])
 
     const { consensusVerifying, consensusVerified: isConsensusVerified } = useSolverLockPolling({

--- a/apps/app/hooks/htlc/useRevealSecret.ts
+++ b/apps/app/hooks/htlc/useRevealSecret.ts
@@ -4,6 +4,7 @@ import { useSecretDerivation } from "@/context/secretDerivationContext";
 import useWallet from "@/hooks/useWallet";
 import posthog from "posthog-js";
 import { useSwapStore } from "@/stores/swapStore";
+import { classifyError } from "@/lib/errors";
 
 export function useRevealSecret() {
     const { source_network, hashlock, solver, updateHTLC, setError, sourceDetails, sourceClient } = useAtomicState()
@@ -41,7 +42,7 @@ export function useRevealSecret() {
             updateSwap(hashlock, { secretRevealed: true })
         }
         catch (e: any) {
-            setError({ message: e.name === 'TrainApiError' ? 'TrainApiError' : (e.details || e.message) })
+            setError(classifyError(e))
             throw e
         }
         finally {

--- a/apps/app/hooks/htlc/useSolverLockPolling.tsx
+++ b/apps/app/hooks/htlc/useSolverLockPolling.tsx
@@ -3,12 +3,10 @@ import useSWR from "swr"
 import { Network, Token } from "@/Models/Network"
 import { LockDetails } from "@/Models/phtlc/PHTLC"
 import { LockParams } from "@/Models/phtlc"
-import { IHTLCClient } from "@train-protocol/sdk"
-
-const CONSENSUS_ERROR_PREFIX = 'Lock details do not match'
+import { IHTLCClient, TrainError, TrainErrorCode } from "@train-protocol/sdk"
 
 function isConsensusMismatchError(err: unknown): boolean {
-    return err instanceof Error && err.message.startsWith(CONSENSUS_ERROR_PREFIX)
+    return err instanceof TrainError && err.code === TrainErrorCode.CONSENSUS_MISMATCH
 }
 
 interface UseSolverLockPollingParams {

--- a/apps/app/lib/errors.ts
+++ b/apps/app/lib/errors.ts
@@ -1,0 +1,107 @@
+import { TrainError, TrainErrorCode } from '@train-protocol/sdk'
+
+// App-only codes — things the SDK doesn't know about
+export enum AppErrorCode {
+    // Wallet interaction
+    USER_REJECTED = 'USER_REJECTED',
+    INSUFFICIENT_FUNDS = 'INSUFFICIENT_FUNDS',
+    CHAIN_MISMATCH = 'CHAIN_MISMATCH',
+    SIGNER_REQUIRED = 'SIGNER_REQUIRED',
+
+    // Transaction
+    TX_REVERTED = 'TX_REVERTED',
+    TIMELOCK_EXPIRED = 'TIMELOCK_EXPIRED',
+    HASHLOCK_MISMATCH = 'HASHLOCK_MISMATCH',
+
+    // Swap lifecycle
+    SOLVER_FAILED = 'SOLVER_FAILED',
+
+    // Catch-all
+    UNKNOWN = 'UNKNOWN',
+}
+
+// Unified type — SDK codes + app-only codes, no duplication
+export type ErrorCode = TrainErrorCode | AppErrorCode
+
+export class AppError extends Error {
+    override name = 'AppError' as const
+    constructor(
+        public readonly code: ErrorCode,
+        message: string,
+    ) {
+        super(message)
+    }
+}
+
+/** Errors where retry is not possible — user must wait for timelock expiry or refund */
+export function isActionDisabled(code: ErrorCode): boolean {
+    return code === AppErrorCode.TIMELOCK_EXPIRED
+        || code === AppErrorCode.SOLVER_FAILED
+        || code === AppErrorCode.HASHLOCK_MISMATCH
+}
+
+const USER_REJECTED_PATTERNS = [
+    'user rejected',
+    'user denied',
+    'user refused',
+    'user_refused_op',
+    'rejected the request',
+    'request rejected',
+    'rejected',
+    'user canceled',
+    'user cancelled',
+]
+
+function extractMessage(raw: unknown): string {
+    if (!raw) return ''
+    if (typeof raw === 'string') return raw
+    const e = raw as Record<string, any>
+    return e?.details || e?.shortMessage || e?.message || e?.code || e?.name || String(raw)
+}
+
+export function classifyError(raw: unknown): AppError {
+    if (raw instanceof AppError) return raw
+
+    // SDK typed errors — preserve code directly
+    if (raw instanceof TrainError) {
+        return new AppError(raw.code, raw.message)
+    }
+
+    const msg = extractMessage(raw)
+    const lower = msg.toLowerCase()
+
+    // User rejection (covers wagmi/viem/starknet/solana/argent patterns)
+    // Exact match for Starknet/Argent-specific rejection message
+    if (msg === 'Execute failed' || USER_REJECTED_PATTERNS.some(p => lower.includes(p))) {
+        return new AppError(AppErrorCode.USER_REJECTED, 'Transaction rejected')
+    }
+
+    // Insufficient funds
+    if (lower.includes('insufficient funds') || lower.includes('insufficient balance')) {
+        return new AppError(AppErrorCode.INSUFFICIENT_FUNDS, 'Insufficient funds')
+    }
+
+    // Chain mismatch (viem/wagmi error name)
+    const name = (raw as any)?.name
+    const causeName = (raw as any)?.cause?.name
+    if (name === 'ChainMismatchError' || causeName === 'ChainMismatchError') {
+        return new AppError(AppErrorCode.CHAIN_MISMATCH, 'Wallet is connected to the wrong network')
+    }
+
+    // Signer required (from blockchain packages)
+    if (lower.includes('signer required') || lower.includes('signer not configured')) {
+        return new AppError(AppErrorCode.SIGNER_REQUIRED, 'Wallet not connected or signer unavailable')
+    }
+
+    // Transaction reverted
+    if (lower.includes('reverted')) {
+        return new AppError(AppErrorCode.TX_REVERTED, msg)
+    }
+
+    // Timelock expired
+    if (lower.includes('timelock expired')) {
+        return new AppError(AppErrorCode.TIMELOCK_EXPIRED, 'Timelock expired')
+    }
+
+    return new AppError(AppErrorCode.UNKNOWN, msg || 'An unexpected error occurred')
+}

--- a/packages/sdk/src/api/client.ts
+++ b/packages/sdk/src/api/client.ts
@@ -5,6 +5,7 @@ import {
     AggregatedQuoteResponse,
     RevealSecretParams,
 } from './types'
+import { TrainError, TrainErrorCode } from '../errors'
 
 export interface TrainApiClientConfig {
     baseUrl: string
@@ -52,19 +53,12 @@ function mapStationNetwork(n: StationNetworkResponse): Network {
     } as unknown as Network
 }
 
-export class TrainApiError extends Error {
-    override name = 'TrainApiError' as const
-    constructor(message: string, public status: number) {
-        super(message)
-    }
-}
-
 export class TrainApiClient {
     private baseUrl: string
 
     constructor(config: TrainApiClientConfig) {
         if (!config.baseUrl) {
-            throw new Error('TrainApiClient: baseUrl is required. Set NEXT_PUBLIC_TRAIN_API env var.')
+            throw new TrainError(TrainErrorCode.API_CLIENT_MISCONFIGURED, 'TrainApiClient: baseUrl is required. Set NEXT_PUBLIC_TRAIN_API env var.')
         }
         this.baseUrl = config.baseUrl.replace(/\/$/, '')
     }
@@ -128,7 +122,7 @@ export class TrainApiClient {
 
         if (!res.ok) {
             const text = await res.text().catch(() => res.statusText)
-            throw new TrainApiError(`${method} ${path} failed (${res.status}): ${text}`, res.status)
+            throw new TrainError(TrainErrorCode.API_REQUEST_FAILED, `${method} ${path} failed (${res.status}): ${text}`)
         }
 
         return res.json() as Promise<T>

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,0 +1,35 @@
+export enum TrainErrorCode {
+    // API
+    API_REQUEST_FAILED = 'API_REQUEST_FAILED',
+    API_CLIENT_MISCONFIGURED = 'API_CLIENT_MISCONFIGURED',
+
+    // Consensus
+    CONSENSUS_MISMATCH = 'CONSENSUS_MISMATCH',
+    CONSENSUS_QUORUM_NOT_MET = 'CONSENSUS_QUORUM_NOT_MET',
+
+    // Registry
+    HTLC_CLIENT_NOT_REGISTERED = 'HTLC_CLIENT_NOT_REGISTERED',
+    WALLET_SIGN_NOT_REGISTERED = 'WALLET_SIGN_NOT_REGISTERED',
+
+    // Passkey
+    PASSKEY_BROWSER_REQUIRED = 'PASSKEY_BROWSER_REQUIRED',
+    PASSKEY_HTTPS_REQUIRED = 'PASSKEY_HTTPS_REQUIRED',
+    PASSKEY_CREATION_FAILED = 'PASSKEY_CREATION_FAILED',
+    PASSKEY_NOT_FOUND = 'PASSKEY_NOT_FOUND',
+    PASSKEY_CANCELLED = 'PASSKEY_CANCELLED',
+    PASSKEY_PRF_UNAVAILABLE = 'PASSKEY_PRF_UNAVAILABLE',
+
+    // Validation
+    INVALID_INPUT = 'INVALID_INPUT',
+}
+
+export class TrainError extends Error {
+    override name = 'TrainError' as const
+    constructor(
+        public readonly code: TrainErrorCode,
+        message: string,
+        options?: ErrorOptions,
+    ) {
+        super(message, options)
+    }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types'
 export * from './login'
 export * from './api'
+export * from './errors'
 export * from './verification'
 export * from './registry'
 export * from './utils'

--- a/packages/sdk/src/login/passkey-service.ts
+++ b/packages/sdk/src/login/passkey-service.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { deriveKeyMaterial, IDENTITY_SALT } from './key-derivation';
+import { TrainError, TrainErrorCode } from '../errors';
 
 const base64URLStringToBuffer = (base64url: string): ArrayBuffer => {
     const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
@@ -126,8 +127,8 @@ export const registerPasskey = async (
         if (existing) return { credentialId: existing };
     }
 
-    if (typeof window === 'undefined') throw new Error('Passkey registration must run in a browser');
-    if (!window.isSecureContext) throw new Error('Passkeys require HTTPS (secure context)');
+    if (typeof window === 'undefined') throw new TrainError(TrainErrorCode.PASSKEY_BROWSER_REQUIRED, 'Passkey registration must run in a browser');
+    if (!window.isSecureContext) throw new TrainError(TrainErrorCode.PASSKEY_HTTPS_REQUIRED, 'Passkeys require HTTPS (secure context)');
 
     const challengeBytes = new Uint8Array(32);
     window.crypto.getRandomValues(challengeBytes);
@@ -159,7 +160,7 @@ export const registerPasskey = async (
     };
 
     const credential = await navigator.credentials.create({ publicKey }) as PublicKeyCredential;
-    if (!credential) throw new Error('Failed to create passkey credential');
+    if (!credential) throw new TrainError(TrainErrorCode.PASSKEY_CREATION_FAILED, 'Failed to create passkey credential');
 
     const credentialId = bufferToBase64URLString(credential.rawId);
     storage?.storeCredentialId(credentialId);
@@ -183,8 +184,8 @@ export const deriveKeyWithPasskey = async (
 ): Promise<{ key: Buffer; credentialId: string }> => {
     const createIfMissing = options?.createIfMissing !== false;
 
-    if (typeof window === 'undefined') throw new Error('Passkey auth must run in a browser');
-    if (!window.isSecureContext) throw new Error('Passkeys require HTTPS (secure context)');
+    if (typeof window === 'undefined') throw new TrainError(TrainErrorCode.PASSKEY_BROWSER_REQUIRED, 'Passkey auth must run in a browser');
+    if (!window.isSecureContext) throw new TrainError(TrainErrorCode.PASSKEY_HTTPS_REQUIRED, 'Passkeys require HTTPS (secure context)');
 
     const prfSalt = getPasskeyPrfSalt();
     const challengeBytes = new Uint8Array(32);
@@ -200,18 +201,18 @@ export const deriveKeyWithPasskey = async (
     let cred = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential | null;
 
     if (!cred) {
-        if (!createIfMissing) throw new Error('No passkey found for this site. Create one instead.');
+        if (!createIfMissing) throw new TrainError(TrainErrorCode.PASSKEY_NOT_FOUND, 'No passkey found for this site. Create one instead.');
         const result = await registerPasskey(true, undefined, storage);
         if (result.key) return { key: result.key, credentialId: result.credentialId };
         cred = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential | null;
-        if (!cred) throw new Error('Passkey authentication was cancelled or no passkey is available');
+        if (!cred) throw new TrainError(TrainErrorCode.PASSKEY_CANCELLED, 'Passkey authentication was cancelled or no passkey is available');
     }
 
     const credentialId = bufferToBase64URLString(cred.rawId);
     const ext: any = cred.getClientExtensionResults?.() ?? {};
     const prfFirst: ArrayBuffer | undefined = ext?.prf?.results?.first;
 
-    if (!prfFirst) throw new Error('Passkey PRF extension not available in this browser/authenticator');
+    if (!prfFirst) throw new TrainError(TrainErrorCode.PASSKEY_PRF_UNAVAILABLE, 'Passkey PRF extension not available in this browser/authenticator');
 
     const ikm = new Uint8Array(prfFirst);
     const identitySalt = Buffer.from(IDENTITY_SALT, 'utf8');

--- a/packages/sdk/src/registry.ts
+++ b/packages/sdk/src/registry.ts
@@ -1,4 +1,5 @@
 import type { IHTLCClient, BaseHTLCClientConfig } from './types/htlc-client'
+import { TrainError, TrainErrorCode } from './errors'
 
 // --- HTLC Client Registry ---
 
@@ -35,7 +36,8 @@ export function createHTLCClient<N extends string>(
 ): IHTLCClient {
     const factory = registry.get(chainNamespace)
     if (!factory) {
-        throw new Error(
+        throw new TrainError(
+            TrainErrorCode.HTLC_CLIENT_NOT_REGISTERED,
             `No HTLC client registered for chain namespace: ${chainNamespace}. ` +
             `Did you forget to call the corresponding register function (e.g. registerEvmSdk())?`
         )
@@ -76,7 +78,8 @@ export function deriveKeyFromWallet<N extends string>(
 ): Promise<Buffer> {
     const factory = walletSignRegistry.get(providerName)
     if (!factory) {
-        throw new Error(
+        throw new TrainError(
+            TrainErrorCode.WALLET_SIGN_NOT_REGISTERED,
             `No wallet sign registered for provider: ${providerName}. ` +
             `Did you forget to call the corresponding register function (e.g. registerEvmSdk())?`
         )

--- a/packages/sdk/src/types/htlc-client.ts
+++ b/packages/sdk/src/types/htlc-client.ts
@@ -2,6 +2,7 @@ import { RedeemSolverParams, UserLockParams, LockParams, RefundParams } from "./
 import { LockDetails } from "./lock"
 import { AtomicResult, RecoveredSwapData } from "./atomic"
 import type { TrainApiClient } from "../api/client"
+import { TrainError, TrainErrorCode } from "../errors"
 
 export type BaseHTLCClientConfig = {
     apiClient: TrainApiClient
@@ -91,7 +92,7 @@ export abstract class HTLCClient implements IHTLCClient {
                     r.timelock === first.timelock &&
                     r.status === first.status
                 )) {
-                    throw new Error('Lock details do not match across the provided nodes')
+                    throw new TrainError(TrainErrorCode.CONSENSUS_MISMATCH, 'Lock details do not match across the provided nodes')
                 }
                 return first
             }
@@ -103,7 +104,8 @@ export abstract class HTLCClient implements IHTLCClient {
             return null
         }
 
-        throw new Error(
+        throw new TrainError(
+            TrainErrorCode.CONSENSUS_QUORUM_NOT_MET,
             `Insufficient node agreement: ${allValidResults.length} of ${totalQueried} nodes returned results, need at least ${effectiveQuorum}`
         )
     }

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,7 +1,9 @@
+import { TrainError, TrainErrorCode } from './errors'
+
 /** Convert a human-readable amount to its smallest unit (e.g. '1.5' with 18 decimals → 1500000000000000000n) */
 export function parseUnits(value: string, decimals: number) {
     if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(value))
-        throw new Error(`Invalid decimal number: ${value}`)
+        throw new TrainError(TrainErrorCode.INVALID_INPUT, `Invalid decimal number: ${value}`)
 
     let [integer, fraction = '0'] = value.split('.')
 
@@ -66,7 +68,7 @@ export function hexToBytes(hex: string, expectedLength: number): number[] {
         bytes.push(parseInt(clean.substring(i, i + 2), 16))
     }
     if (bytes.length !== expectedLength) {
-        throw new Error(`Expected ${expectedLength} bytes, got ${bytes.length}`)
+        throw new TrainError(TrainErrorCode.INVALID_INPUT, `Expected ${expectedLength} bytes, got ${bytes.length}`)
     }
     return bytes
 }


### PR DESCRIPTION
Replace fragile string matching (error.includes, error ===) with typed error codes. SDK gets TrainError/TrainErrorCode for protocol-level errors. App gets AppError/AppErrorCode for UI-level errors with a unified classifyError() that centralizes all pattern matching. Errors flow as typed objects through atomicContext instead of raw strings.