### PR TITLE
Fix: improve Aztec wallet connection handling and error states

### DIFF
--- a/apps/app/components/Icons/ConnectorIcons.tsx
+++ b/apps/app/components/Icons/ConnectorIcons.tsx
@@ -16,8 +16,8 @@ import OpenMask from "./Wallets/OpenMask";
 import TON from "./Wallets/TON";
 import MyTonWallet from "./Wallets/MyTonWallet";
 import GlowIcon from "./Wallets/Glow";
-import LogoPlaceholder from "./LogoPlaceholder";
 import Azguard from "./Wallets/Azguard";
+import { cn } from "@/lib/utils";
 
 
 export const ResolveConnectorIcon = ({
@@ -77,11 +77,8 @@ export const ResolveConnectorIcon = ({
             );
         case KnownConnectors.Aztec:
             return (
-                <IconsWrapper className={className}>
-                    <Azguard className={iconClassName} />
-                    <LogoPlaceholder className={iconClassName} />
-                    <LogoPlaceholder className={iconClassName} />
-                    <LogoPlaceholder className={iconClassName} />
+                <IconsWrapper className={className} single>
+                    <Azguard className={cn(iconClassName, "size-[5.25rem]")} />
                 </IconsWrapper>
             );
         default:
@@ -96,7 +93,10 @@ export const ResolveConnectorIcon = ({
     }
 };
 
-const IconsWrapper = ({ children, className }: { children: React.ReactNode, className?: string }) => {
+const IconsWrapper = ({ children, className, single }: { children: React.ReactNode, className?: string, single?: boolean }) => {
+    if (single) {
+        return <div className="min-w-fit">{children}</div>;
+    }
     return <div className={className ?? "-space-x-2 flex"}>{children}</div>;
 }
 

--- a/apps/app/components/WalletModal/ConnectorsList.tsx
+++ b/apps/app/components/WalletModal/ConnectorsList.tsx
@@ -90,8 +90,12 @@ const ConnectorsList: FC<{ onFinish: (result: Wallet | undefined) => void }> = (
             setSelectedConnector(undefined)
         } catch (e) {
             console.log(e)
+            if (e?.extensionNotFound) {
+                setSelectedConnector(connector ? { ...connector, extensionNotFound: true } : undefined)
+                return
+            }
             const message = (e?.message || e?.details || '').toLowerCase()
-            if (e?.name === 'WalletWindowClosedError' || message.includes('rejected') || message.includes('denied')) {
+            if (e?.name === 'WalletWindowClosedError' || message.includes('rejected') || message.includes('denied') || message.includes('declined')) {
                 setConnectionError("You've declined the wallet connection request")
             } else {
                 setConnectionError(e.message || e.details || 'Something went wrong')

--- a/apps/app/components/WalletProviders/AztecWalletProvider.tsx
+++ b/apps/app/components/WalletProviders/AztecWalletProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from "react";
+import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from "react";
 import type { Wallet as AztecWallet } from "@aztec/aztec.js/wallet";
 import type { WalletProvider as AztecSDKWalletProvider, PendingConnection } from "@aztec/wallet-sdk/manager";
 import { AZTEC_APP_ID, useAztecChainInfo } from "@/lib/wallets/aztec/configs";
@@ -9,19 +9,17 @@ import SubmitButton from "../buttons/submitButton";
 interface AztecWalletContextType {
     connect: (providerId: string) => Promise<AztecWallet>;
     disconnect: () => Promise<void>;
-    startDiscovery: () => void;
 }
 
 const AztecWalletContext = createContext<AztecWalletContextType | undefined>(undefined);
 
 export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-    const { setWallet, setDiscoveredProviders, addDiscoveredProvider, setIsDiscovering } = useAztecWalletStore();
+    const { setWallet } = useAztecWalletStore();
     const [pendingConnection, setPendingConnection] = useState<PendingConnection | null>(null);
     const [verificationEmojis, setVerificationEmojis] = useState<string | null>(null);
 
     const activeProviderRef = useRef<AztecSDKWalletProvider | null>(null);
-    const discoveryRef = useRef<{ cancel: () => void } | null>(null);
-    const isDiscoveringRef = useRef(false);
+
     const pendingResolveRef = useRef<((wallet: AztecWallet) => void) | null>(null);
     const pendingRejectRef = useRef<((error: Error) => void) | null>(null);
     const disconnectUnsubRef = useRef<(() => void) | null>(null);
@@ -36,48 +34,6 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
         activeProviderRef.current = null;
     }, [setWallet]);
 
-    const startDiscovery = useCallback(async () => {
-        if (typeof window === 'undefined' || isDiscoveringRef.current) return;
-
-        try {
-            isDiscoveringRef.current = true;
-            setIsDiscovering(true);
-            setDiscoveredProviders([]);
-
-            const { WalletManager } = await import("@aztec/wallet-sdk/manager");
-
-            const manager = WalletManager.configure({
-                extensions: { enabled: true },
-            });
-
-            const discovery = manager.getAvailableWallets({
-                chainInfo: await chainInfo(),
-                appId: AZTEC_APP_ID,
-                timeout: 10000,
-                onWalletDiscovered: (provider) => {
-                    addDiscoveredProvider(provider);
-                },
-            });
-
-            discoveryRef.current = discovery;
-            await discovery.done;
-        } catch (error) {
-            console.error("Error during wallet discovery:", error);
-        } finally {
-            isDiscoveringRef.current = false;
-            setIsDiscovering(false);
-        }
-    }, [chainInfo]);
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-        startDiscovery();
-
-        return () => {
-            discoveryRef.current?.cancel();
-        };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
     const connect = useCallback(async (providerId: string): Promise<AztecWallet> => {
         // Read directly from store to avoid stale closures
         let provider = useAztecWalletStore.getState().discoveredProviders.find(p => p.id === providerId);
@@ -91,7 +47,7 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
             const discovery = manager.getAvailableWallets({
                 chainInfo: await chainInfo(),
                 appId: AZTEC_APP_ID,
-                timeout: 10000,
+                timeout: 30000,
                 onWalletDiscovered: (p) => {
                     useAztecWalletStore.getState().addDiscoveredProvider(p);
                     if (p.id === providerId) {
@@ -100,7 +56,6 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
                     }
                 },
             });
-
             await discovery.done;
             provider = freshProvider ?? undefined;
         }
@@ -111,7 +66,12 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
 
         const { hashToEmoji } = await import("@aztec/wallet-sdk/crypto");
 
-        const pending = await provider.establishSecureChannel(AZTEC_APP_ID);
+        let pending: PendingConnection;
+        try {
+            pending = await provider.establishSecureChannel(AZTEC_APP_ID);
+        } catch {
+            throw new Error("Connection declined by wallet");
+        }
 
         const emojis = hashToEmoji(pending.verificationHash);
         setPendingConnection(pending);
@@ -157,8 +117,6 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
                         const provider = activeProviderRef.current;
                         if (!provider || provider.isDisconnected?.() !== false) {
                             resetConnection();
-                            // Re-run discovery to get fresh providers
-                            startDiscovery();
                         }
                     }, 1000);
                 });
@@ -202,16 +160,13 @@ export const AztecWalletProvider: React.FC<{ children: ReactNode }> = ({ childre
             console.error("Error disconnecting:", error);
         } finally {
             resetConnection();
-            // Re-run discovery to get fresh providers with new MessagePorts
-            startDiscovery();
         }
-    }, [resetConnection, startDiscovery]);
+    }, [resetConnection]);
 
     return (
         <AztecWalletContext.Provider value={{
             connect,
             disconnect,
-            startDiscovery,
         }}>
             <ActiveAztecAccountProvider>
                 {children}

--- a/apps/app/lib/wallets/aztec/KnownAztecConnectors.tsx
+++ b/apps/app/lib/wallets/aztec/KnownAztecConnectors.tsx
@@ -3,10 +3,17 @@ import Azguard from "@/components/Icons/Wallets/Azguard"
 const KnownAztecConnectors = [
     {
         id: 'azguard-wallet',
+        name: 'Azguard',
         icon: Azguard
     },
     {
         id: 'azguard wallet',
+        name: 'Azguard',
+        icon: Azguard
+    },
+    {
+        id: 'azguard',
+        name: 'Azguard',
         icon: Azguard
     },
 ]

--- a/apps/app/lib/wallets/aztec/useAztec.ts
+++ b/apps/app/lib/wallets/aztec/useAztec.ts
@@ -6,8 +6,8 @@ import { extractAztecAddress } from "./utils";
 import { useCallback, useMemo } from "react";
 import { useAztecWalletContext } from "@/components/WalletProviders/AztecWalletProvider";
 import { useActiveAztecAccount } from "@/components/WalletProviders/ActiveAztecAccount";
-import { useAztecWalletStore } from "@/stores/aztecWalletStore";
 import { useWalletStore } from "@/stores/walletStore";
+import KnownAztecConnectors from "./KnownAztecConnectors";
 
 const commonSupportedNetworks = [
     KnownInternalNames.Networks.AztecDevnet,
@@ -21,7 +21,6 @@ export default function useAztec(): WalletProvider {
 
     const { connect, disconnect } = useAztecWalletContext();
     const { activeAddress: activeSelectedAddress, setActiveAddress } = useActiveAztecAccount();
-    const { discoveredProviders } = useAztecWalletStore();
     const wallets = useWalletStore((state) => state.connectedWallets)
     const addWallet = useWalletStore((state) => state.connectWallet)
     const removeWallet = useWalletStore((state) => state.disconnectWallet)
@@ -55,7 +54,7 @@ export default function useAztec(): WalletProvider {
             autofillSupportedNetworks: commonSupportedNetworks,
             networkIcon: networks.find(n => commonSupportedNetworks.some(name => name === n.caip2Id))?.logoUrl
         }
-    }, [wallets, networks, discoveredProviders, disconnectWallets, activeSelectedAddress])
+    }, [wallets, networks, disconnectWallets, activeSelectedAddress])
 
     const connectWallet = async (params?: { connector?: InternalConnector }) => {
         try {
@@ -80,18 +79,17 @@ export default function useAztec(): WalletProvider {
             }
 
             if (connectedAddresses.length > 0) {
-                const activeProvider = discoveredProviders.find(p => p.id === providerId);
-                const walletName = activeProvider?.name ?? 'Aztec Wallet';
+                const walletName = params?.connector?.name ?? 'Azguard';
                 const primaryAddress = connectedAddresses[0];
 
                 const newWallet: Wallet = {
-                    id: activeProvider?.id ?? '',
+                    id: providerId,
                     displayName: `${walletName} - Aztec`,
                     addresses: connectedAddresses,
                     address: primaryAddress,
                     providerName: name,
                     isActive: true,
-                    icon: resolveWalletConnectorIcon({ connector: activeProvider?.id ?? name, address: primaryAddress }),
+                    icon: resolveWalletConnectorIcon({ connector: providerId, address: primaryAddress }),
                     disconnect: () => disconnectWallets(),
                     withdrawalSupportedNetworks: commonSupportedNetworks,
                     asSourceSupportedNetworks: commonSupportedNetworks,
@@ -102,21 +100,27 @@ export default function useAztec(): WalletProvider {
                 return newWallet;
             }
         } catch (error) {
+            if (error instanceof Error && error.message.includes('not found')) {
+                const err = new Error('Azguard wallet extension not found. Please install it and try again.');
+                (err as any).extensionNotFound = true;
+                throw err;
+            }
             console.error(`Error connecting Aztec wallet:`, error);
             throw error;
         }
     }
 
     const availableWalletsForConnect: InternalConnector[] = useMemo(() => {
-        return discoveredProviders.map(provider => ({
-            id: provider.id,
-            name: provider.name,
-            icon: provider.icon,
+        const azguard = KnownAztecConnectors[0];
+        return [{
+            id: azguard.id,
+            name: azguard.name,
             providerName: name,
             extensionNotFound: false,
             hasBrowserExtension: true,
-        }));
-    }, [discoveredProviders])
+            installUrl: 'https://azguardwallet.io/',
+        }];
+    }, [])
 
     const switchAccount = useCallback(async (_wallet: Wallet, address: string) => {
         setActiveAddress(address);


### PR DESCRIPTION
- Remove auto-discovery on mount to avoid triggering extension popups
- Use hardcoded connector list instead of dynamic discovery results
- Increase discovery timeout to 30s for rejected/closed popup handling
- Catch establishSecureChannel failures as "Connection declined by wallet"
- Add extensionNotFound handling with install link for Azguard
- Detect 'declined' errors in ConnectorsList alongside rejected/denied