### PR TITLE
fix: surface wallet rejection error to user during pre-lock swap phase

### DIFF
--- a/apps/app/components/Swap/AtomicChat/Actions/UserActions.tsx
+++ b/apps/app/components/Swap/AtomicChat/Actions/UserActions.tsx
@@ -7,7 +7,6 @@ import posthog from "posthog-js";
 import { SwapViewType } from ".";
 import { useSelectedAccount } from "@/context/swapAccounts";
 import { Address } from "@/lib/address";
-import { NetworkContractType } from "@/Models/Network";
 import { useSwapStore } from "@/stores/swapStore";
 import { useFormikContext } from "formik";
 import type { SwapFormValues } from "@/components/DTOs/SwapFormValues";
@@ -16,9 +15,10 @@ type UserCommitActionProps = {
     quote?: SwapQuote
     solverId?: string
     type: SwapViewType
+    setError: (error: Error | undefined) => void
 }
 
-export const UserLockAction: FC<UserCommitActionProps> = ({ quote, solverId, type }) => {
+export const UserLockAction: FC<UserCommitActionProps> = ({ quote, solverId, type, setError }) => {
     // Before lock: read from Formik (form values have Network/Token objects)
     const { values } = useFormikContext<SwapFormValues>()
     const { hashlock } = useActiveSwap()
@@ -78,6 +78,7 @@ export const UserLockAction: FC<UserCommitActionProps> = ({ quote, solverId, typ
         }
         catch (e) {
             console.error('[UserLock] failed', e?.message ?? String(e), ...(e?.logs ? [e.logs] : []))
+            setError(e instanceof Error ? e : new Error(String(e)))
         }
     }
 

--- a/apps/app/components/Swap/AtomicChat/Actions/index.tsx
+++ b/apps/app/components/Swap/AtomicChat/Actions/index.tsx
@@ -29,15 +29,21 @@ type ActionsProps = {
 
 export const Actions: FC<ActionsProps> = ({ quote, solverId, type }) => {
     const { status: commitStatus, error } = useActiveSwap()
+    const [actionError, setActionError] = useState<Error | undefined>(undefined)
+
+    const displayError = error?.message ?? actionError?.message
+    const displayErrorCode = error?.code
 
     return (
         <>
-            {error && <TransactionMessage error={error.message} errorCode={error.code} />}
+            {displayError && <TransactionMessage error={displayError} errorCode={displayErrorCode} />}
             <DestinationWalletWrapper>
                 <ResolveAction
                     commitStatus={commitStatus}
                     error={error?.message}
                     errorCode={error?.code}
+                    actionError={actionError}
+                    setActionError={setActionError}
                     quote={quote}
                     solverId={solverId}
                     type={type}
@@ -51,20 +57,25 @@ type ResolveActionProps = {
     commitStatus: HTLCStatus
     error: string | undefined
     errorCode?: TrainErrorCode
+    actionError?: Error
+    setActionError: (error: Error | undefined) => void
     quote?: SwapQuote
     solverId?: string
     type: SwapViewType
 }
 
-const ResolveAction: FC<ResolveActionProps> = ({ commitStatus, error, errorCode, quote, solverId, type }) => {
+const ResolveAction: FC<ResolveActionProps> = ({ commitStatus, error, errorCode, actionError, setActionError, quote, solverId, type }) => {
     const setActiveHashlock = useSwapStore(s => s.setActiveHashlock)
     const goHome = useGoHome()
 
-    if (error && errorCode === TrainErrorCode.UserLockTransactionFailed) {
+    if ((error && errorCode === TrainErrorCode.UserLockTransactionFailed) || actionError) {
         const handleRetry = () => {
-            setActiveHashlock(null)
-            if (type === 'widget') {
-                goHome()
+            setActionError(undefined)
+            if (error) {
+                setActiveHashlock(null)
+                if (type === 'widget') {
+                    goHome()
+                }
             }
         }
 
@@ -91,7 +102,7 @@ const ResolveAction: FC<ResolveActionProps> = ({ commitStatus, error, errorCode,
         case HTLCStatus.UserLocked:
             return <></>
         default:
-            return <UserLockAction quote={quote} solverId={solverId} type={type} />
+            return <UserLockAction quote={quote} solverId={solverId} type={type} setError={setActionError} />
     }
 }
 


### PR DESCRIPTION
When a user rejects the wallet transaction during createSwap, the error was only logged to console with no UI feedback. This restores the error propagation that was lost when atomicContext was replaced with @train-protocol/react hooks. Uses useState in Actions passed as a callback to UserLockAction, which naturally resets on modal unmount.