### PR TITLE
Fix Aztec network not appearing in available networks

### DIFF
--- a/apps/app/lib/rpc/nonEvmNodes.ts
+++ b/apps/app/lib/rpc/nonEvmNodes.ts
@@ -29,6 +29,9 @@ export const NON_EVM_NODES: Record<string, NetworkNode[]> = {
     ],
 
     // ── Aztec ──
+    'aztec:aztec-devnet': [
+        { url: 'https://rpc.testnet.aztec-labs.com', providerName: 'aztec-labs' },
+    ],
     'aztec:4138294185': [
         { url: 'https://rpc.testnet.aztec-labs.com', providerName: 'aztec-labs' },
     ],

--- a/apps/app/lib/rpc/nonEvmNodes.ts
+++ b/apps/app/lib/rpc/nonEvmNodes.ts
@@ -29,7 +29,7 @@ export const NON_EVM_NODES: Record<string, NetworkNode[]> = {
     ],
 
     // ── Aztec ──
-    'aztec:aztec-devnet': [
+    'aztec:4138294185': [
         { url: 'https://rpc.testnet.aztec-labs.com', providerName: 'aztec-labs' },
     ],
 


### PR DESCRIPTION
## Summary
- The Station API returns Aztec Testnet as `aztec:4138294185`, but `apps/app/lib/rpc/nonEvmNodes.ts` registered the RPC under `aztec:aztec-devnet`.
- `getSettings` filters out networks with no resolved RPC nodes (`apps/app/lib/getSettings.ts:43`), so Aztec was silently dropped before reaching the UI.
- Fix: re-key the Aztec entry to the CAIP-2 ID returned by the API (`aztec:4138294185`).

## Test plan
- [ ] `pnpm dev` and confirm Aztec Testnet shows up in the route picker
- [ ] Verify `resolveNodes("aztec:4138294185")` returns the `rpc.testnet.aztec-labs.com` node
- [ ] Smoke-test an Aztec swap (source or destination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)