### PR TITLE
summary: USD mode swap, truncated-amount tooltips, mobile popover restyle

### DIFF
--- a/apps/app/components/Modal/mobileTooltip.tsx
+++ b/apps/app/components/Modal/mobileTooltip.tsx
@@ -19,7 +19,10 @@ const MobileTooltip: FC<MobileTooltipProps> = ({ children, trigger }) => {
                         <PopoverTrigger asChild>
                             {trigger}
                         </PopoverTrigger>
-                        <PopoverContent side="top" className="max-w-[300px] text-sm">
+                        <PopoverContent
+                            side="top"
+                            className="inline-flex w-fit max-w-xs items-center gap-1.5 rounded-xl bg-foreground px-3 py-1.5 text-xs text-background shadow-none ring-0 flex-row"
+                        >
                             {children}
                         </PopoverContent>
                     </Popover>

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
@@ -39,7 +39,7 @@ const TokenAmount: FC<{ display: ReactNode; full: string; symbol: string; trunca
 }
 
 const UsdAmount: FC<{ value: number | string | undefined }> = ({ value }) => (
-    <NumberFlow value={Number(value) || 0} prefix="$" trend={0} />
+    <NumberFlow value={Number(value) || 0} prefix="$" trend={0} className="leading-[inherit]" />
 )
 
 const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, source, destination, requestedAmount, receiveAmount, }) => {
@@ -58,7 +58,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
 
     const sendToken = (
         <TokenAmount
-            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} className="leading-[inherit]" />}
             full={truncateDecimals(requestedAmountNum, sourceCurrency.decimals)}
             symbol={sourceCurrency.symbol}
             truncated={isSendTruncated}
@@ -67,7 +67,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
     const sendUsd = <UsdAmount value={requestedAmountInUsd} />
     const recvToken = (
         <TokenAmount
-            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} className="leading-[inherit]" />}
             full={truncateDecimals(receiveAmountNum, destinationCurrency.decimals)}
             symbol={destinationCurrency.symbol}
             truncated={isReceiveTruncated}
@@ -109,7 +109,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                         {
                             receiveAmount && (
                                 <div className="flex flex-col items-end w-full col-start-6 col-span-5 min-w-0">
-                                    <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
+                                    <p className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end min-w-0 w-full">
                                         {isUsdMode ? recvUsd : recvToken}
                                     </p>
                                     <p className="text-secondary-text text-sm leading-5 flex items-center gap-1 font-medium">

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 import { truncateDecimals } from "@/components/utils/RoundDecimals";
 import { ExtendedNetwork, ExtendedToken } from "@/Models/Network";
 import { ImageWithFallback } from "@/components/Common/ImageWithFallback";
@@ -6,6 +6,8 @@ import { ArrowDown } from "lucide-react";
 import NumberFlow from "@number-flow/react";
 import { resolveTokenLogoUrl } from "@/components/utils/resolveTokenLogoUrl";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
+import MobileTooltip from "@/components/Modal/mobileTooltip";
+import { useUsdModeStore } from "@/stores/usdModeStore";
 
 
 type AtomicSummaryProps = {
@@ -17,18 +19,61 @@ type AtomicSummaryProps = {
     receiveAmount: string | undefined;
 }
 
-const RECEIVE_MAX_FRACTION_DIGITS_MOBILE = 8;
-const RECEIVE_MAX_FRACTION_DIGITS_DESKTOP = 12;
+const TOKEN_MAX_FRACTION_DIGITS_MOBILE = 8;
+const TOKEN_MAX_FRACTION_DIGITS_DESKTOP = 12;
+
+const TokenAmount: FC<{ display: ReactNode; full: string; symbol: string; truncated: boolean }> = ({ display, full, symbol, truncated }) => {
+    const node = (
+        <span className="inline-flex items-center min-w-0 gap-1">
+            <span className="truncate min-w-0">{display}</span>
+            {truncated && <span className="shrink-0">...</span>}
+            <span className="shrink-0">{symbol}</span>
+        </span>
+    )
+    if (!truncated) return node
+    return (
+        <MobileTooltip trigger={<span>{node}</span>}>
+            {full} {symbol}
+        </MobileTooltip>
+    )
+}
+
+const UsdAmount: FC<{ value: number | string | undefined }> = ({ value }) => (
+    <NumberFlow value={Number(value) || 0} prefix="$" trend={0} />
+)
 
 const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, source, destination, requestedAmount, receiveAmount, }) => {
 
     const { isMobile } = useWindowDimensions()
-    const receiveMaxFractionDigits = isMobile ? RECEIVE_MAX_FRACTION_DIGITS_MOBILE : RECEIVE_MAX_FRACTION_DIGITS_DESKTOP
+    const maxFractionDigits = isMobile ? TOKEN_MAX_FRACTION_DIGITS_MOBILE : TOKEN_MAX_FRACTION_DIGITS_DESKTOP
+    const isUsdMode = useUsdModeStore(s => s.isUsdMode)
 
     const requestedAmountInUsd = (requestedAmount && sourceCurrency?.priceInUsd) ? (sourceCurrency.priceInUsd * Number(requestedAmount)).toFixed(2) : undefined
     const receiveAmountInUsd = (receiveAmount && destinationCurrency?.priceInUsd) ? (destinationCurrency.priceInUsd * Number(receiveAmount)).toFixed(2) : undefined
+
+    const requestedAmountNum = Number(requestedAmount)
+    const isSendTruncated = requestedAmountNum > 0 && isFinite(requestedAmountNum) && Number(requestedAmountNum.toFixed(maxFractionDigits)) !== requestedAmountNum
     const receiveAmountNum = Number(receiveAmount)
-    const isReceiveTruncated = receiveAmountNum > 0 && isFinite(receiveAmountNum) && Number(receiveAmountNum.toFixed(receiveMaxFractionDigits)) !== receiveAmountNum
+    const isReceiveTruncated = receiveAmountNum > 0 && isFinite(receiveAmountNum) && Number(receiveAmountNum.toFixed(maxFractionDigits)) !== receiveAmountNum
+
+    const sendToken = (
+        <TokenAmount
+            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            full={truncateDecimals(requestedAmountNum, sourceCurrency.decimals)}
+            symbol={sourceCurrency.symbol}
+            truncated={isSendTruncated}
+        />
+    )
+    const sendUsd = <UsdAmount value={requestedAmountInUsd} />
+    const recvToken = (
+        <TokenAmount
+            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            full={truncateDecimals(receiveAmountNum, destinationCurrency.decimals)}
+            symbol={destinationCurrency.symbol}
+            truncated={isReceiveTruncated}
+        />
+    )
+    const recvUsd = <UsdAmount value={receiveAmountInUsd} />
 
     return (
         <>
@@ -40,14 +85,16 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                             token={sourceCurrency}
                         />
                         <div className="flex flex-col col-start-6 col-span-5 items-end min-w-0">
-                            {
-                                requestedAmount &&
-                                <p className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end min-w-0 w-full space-x-1">
-                                    <span className="truncate min-w-0">{truncateDecimals(Number(requestedAmount), sourceCurrency.decimals)}</span>
-                                    <span className="shrink-0">{sourceCurrency.symbol}</span>
-                                </p>
-                            }
-                            <p className="text-secondary-text text-sm leading-5 flex font-medium justify-end"><NumberFlow value={Number(requestedAmountInUsd) || 0} prefix="$" trend={0} /></p>
+                            {requestedAmount && (
+                                <>
+                                    <p className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end min-w-0 w-full">
+                                        {isUsdMode ? sendUsd : sendToken}
+                                    </p>
+                                    <p className="text-secondary-text text-sm leading-5 flex font-medium justify-end gap-1">
+                                        {isUsdMode ? sendToken : sendUsd}
+                                    </p>
+                                </>
+                            )}
                         </div>
                     </div>
                     <div className="relative text-secondary-text">
@@ -62,15 +109,11 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                         {
                             receiveAmount && (
                                 <div className="flex flex-col items-end w-full col-start-6 col-span-5 min-w-0">
-                                    <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full space-x-1">
-                                        <span className="flex items-center min-w-0">
-                                            <NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: receiveMaxFractionDigits }} />
-                                            {isReceiveTruncated && <span className="shrink-0">...</span>}
-                                        </span>
-                                        <span className="shrink-0">{destinationCurrency.symbol}</span>
+                                    <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
+                                        {isUsdMode ? recvUsd : recvToken}
                                     </p>
                                     <p className="text-secondary-text text-sm leading-5 flex items-center gap-1 font-medium">
-                                        <NumberFlow value={Number(receiveAmountInUsd) || 0} prefix="$" trend={0} />
+                                        {isUsdMode ? recvToken : recvUsd}
                                     </p>
                                 </div>
                             )

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useMemo } from "react";
 import { truncateDecimals } from "@/components/utils/RoundDecimals";
 import { ExtendedNetwork, ExtendedToken } from "@/Models/Network";
 import { ImageWithFallback } from "@/components/Common/ImageWithFallback";
@@ -55,25 +55,26 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
     const isSendTruncated = requestedAmountNum > 0 && isFinite(requestedAmountNum) && Number(requestedAmountNum.toFixed(maxFractionDigits)) !== requestedAmountNum
     const receiveAmountNum = Number(receiveAmount)
     const isReceiveTruncated = receiveAmountNum > 0 && isFinite(receiveAmountNum) && Number(receiveAmountNum.toFixed(maxFractionDigits)) !== receiveAmountNum
+    const tokenAmountFormat = useMemo(() => ({ maximumFractionDigits: maxFractionDigits }), [maxFractionDigits])
 
-    const sendToken = (
+    const sendToken = useMemo(() => (
         <TokenAmount
-            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            display={<NumberFlow value={requestedAmountNum} trend={0} format={tokenAmountFormat} />}
             full={truncateDecimals(requestedAmountNum, sourceCurrency.decimals)}
             symbol={sourceCurrency.symbol}
             truncated={isSendTruncated}
         />
-    )
-    const sendUsd = <UsdAmount value={requestedAmountInUsd} />
-    const recvToken = (
+    ), [requestedAmountNum, sourceCurrency.decimals, sourceCurrency.symbol, isSendTruncated, tokenAmountFormat])
+    const sendUsd = useMemo(() => <UsdAmount value={requestedAmountInUsd} />, [requestedAmountInUsd])
+    const recvToken = useMemo(() => (
         <TokenAmount
-            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
+            display={<NumberFlow value={receiveAmountNum} trend={0} format={tokenAmountFormat} />}
             full={truncateDecimals(receiveAmountNum, destinationCurrency.decimals)}
             symbol={destinationCurrency.symbol}
             truncated={isReceiveTruncated}
         />
-    )
-    const recvUsd = <UsdAmount value={receiveAmountInUsd} />
+    ), [receiveAmountNum, destinationCurrency.decimals, destinationCurrency.symbol, isReceiveTruncated, tokenAmountFormat])
+    const recvUsd = useMemo(() => <UsdAmount value={receiveAmountInUsd} />, [receiveAmountInUsd])
 
     return (
         <>

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
@@ -39,7 +39,7 @@ const TokenAmount: FC<{ display: ReactNode; full: string; symbol: string; trunca
 }
 
 const UsdAmount: FC<{ value: number | string | undefined }> = ({ value }) => (
-    <NumberFlow value={Number(value) || 0} prefix="$" trend={0} className="leading-[inherit]" />
+    <NumberFlow value={Number(value) || 0} prefix="$" trend={0} />
 )
 
 const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, source, destination, requestedAmount, receiveAmount, }) => {
@@ -58,7 +58,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
 
     const sendToken = (
         <TokenAmount
-            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} className="leading-[inherit]" />}
+            display={<NumberFlow value={requestedAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
             full={truncateDecimals(requestedAmountNum, sourceCurrency.decimals)}
             symbol={sourceCurrency.symbol}
             truncated={isSendTruncated}
@@ -67,7 +67,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
     const sendUsd = <UsdAmount value={requestedAmountInUsd} />
     const recvToken = (
         <TokenAmount
-            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} className="leading-[inherit]" />}
+            display={<NumberFlow value={receiveAmountNum} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />}
             full={truncateDecimals(receiveAmountNum, destinationCurrency.decimals)}
             symbol={destinationCurrency.symbol}
             truncated={isReceiveTruncated}
@@ -87,10 +87,10 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                         <div className="flex flex-col col-start-6 col-span-5 items-end min-w-0">
                             {requestedAmount && (
                                 <>
-                                    <p className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end min-w-0 w-full">
+                                    <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
                                         {isUsdMode ? sendUsd : sendToken}
                                     </p>
-                                    <p className="text-secondary-text text-sm leading-5 flex font-medium justify-end gap-1">
+                                    <p className="text-secondary-text text-sm leading-5 flex items-center font-medium justify-end gap-1">
                                         {isUsdMode ? sendToken : sendUsd}
                                     </p>
                                 </>
@@ -109,7 +109,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                         {
                             receiveAmount && (
                                 <div className="flex flex-col items-end w-full col-start-6 col-span-5 min-w-0">
-                                    <p className="text-primary-text text-xl leading-6 font-normal flex items-center justify-end min-w-0 w-full">
+                                    <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
                                         {isUsdMode ? recvUsd : recvToken}
                                     </p>
                                     <p className="text-secondary-text text-sm leading-5 flex items-center gap-1 font-medium">

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useMemo } from "react";
+import { FC } from "react";
 import { truncateDecimals } from "@/components/utils/RoundDecimals";
 import { ExtendedNetwork, ExtendedToken } from "@/Models/Network";
 import { ImageWithFallback } from "@/components/Common/ImageWithFallback";
@@ -22,10 +22,15 @@ type AtomicSummaryProps = {
 const TOKEN_MAX_FRACTION_DIGITS_MOBILE = 8;
 const TOKEN_MAX_FRACTION_DIGITS_DESKTOP = 12;
 
-const TokenAmount: FC<{ display: ReactNode; full: string; symbol: string; truncated: boolean }> = ({ display, full, symbol, truncated }) => {
+const TokenAmount: FC<{ amount: number; decimals: number; maxFractionDigits: number; symbol: string }> = ({ amount, decimals, maxFractionDigits, symbol }) => {
+    const full = truncateDecimals(amount, decimals)
+    const truncated = amount > 0 && isFinite(amount) && Number(amount.toFixed(maxFractionDigits)) !== amount
+
     const node = (
         <span className="inline-flex items-center min-w-0 gap-1">
-            <span className="truncate min-w-0">{display}</span>
+            <span className="truncate min-w-0">
+                <NumberFlow value={amount} trend={0} format={{ maximumFractionDigits: maxFractionDigits }} />
+            </span>
             {truncated && <span className="shrink-0">...</span>}
             <span className="shrink-0">{symbol}</span>
         </span>
@@ -52,29 +57,7 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
     const receiveAmountInUsd = (receiveAmount && destinationCurrency?.priceInUsd) ? (destinationCurrency.priceInUsd * Number(receiveAmount)).toFixed(2) : undefined
 
     const requestedAmountNum = Number(requestedAmount)
-    const isSendTruncated = requestedAmountNum > 0 && isFinite(requestedAmountNum) && Number(requestedAmountNum.toFixed(maxFractionDigits)) !== requestedAmountNum
     const receiveAmountNum = Number(receiveAmount)
-    const isReceiveTruncated = receiveAmountNum > 0 && isFinite(receiveAmountNum) && Number(receiveAmountNum.toFixed(maxFractionDigits)) !== receiveAmountNum
-    const tokenAmountFormat = useMemo(() => ({ maximumFractionDigits: maxFractionDigits }), [maxFractionDigits])
-
-    const sendToken = useMemo(() => (
-        <TokenAmount
-            display={<NumberFlow value={requestedAmountNum} trend={0} format={tokenAmountFormat} />}
-            full={truncateDecimals(requestedAmountNum, sourceCurrency.decimals)}
-            symbol={sourceCurrency.symbol}
-            truncated={isSendTruncated}
-        />
-    ), [requestedAmountNum, sourceCurrency.decimals, sourceCurrency.symbol, isSendTruncated, tokenAmountFormat])
-    const sendUsd = useMemo(() => <UsdAmount value={requestedAmountInUsd} />, [requestedAmountInUsd])
-    const recvToken = useMemo(() => (
-        <TokenAmount
-            display={<NumberFlow value={receiveAmountNum} trend={0} format={tokenAmountFormat} />}
-            full={truncateDecimals(receiveAmountNum, destinationCurrency.decimals)}
-            symbol={destinationCurrency.symbol}
-            truncated={isReceiveTruncated}
-        />
-    ), [receiveAmountNum, destinationCurrency.decimals, destinationCurrency.symbol, isReceiveTruncated, tokenAmountFormat])
-    const recvUsd = useMemo(() => <UsdAmount value={receiveAmountInUsd} />, [receiveAmountInUsd])
 
     return (
         <>
@@ -89,10 +72,28 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                             {requestedAmount && (
                                 <>
                                     <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
-                                        {isUsdMode ? sendUsd : sendToken}
+                                        {isUsdMode ? (
+                                            <UsdAmount value={requestedAmountInUsd} />
+                                        ) : (
+                                            <TokenAmount
+                                                amount={requestedAmountNum}
+                                                decimals={sourceCurrency.decimals}
+                                                maxFractionDigits={maxFractionDigits}
+                                                symbol={sourceCurrency.symbol}
+                                            />
+                                        )}
                                     </p>
                                     <p className="text-secondary-text text-sm leading-5 flex items-center font-medium justify-end gap-1">
-                                        {isUsdMode ? sendToken : sendUsd}
+                                        {isUsdMode ? (
+                                            <TokenAmount
+                                                amount={requestedAmountNum}
+                                                decimals={sourceCurrency.decimals}
+                                                maxFractionDigits={maxFractionDigits}
+                                                symbol={sourceCurrency.symbol}
+                                            />
+                                        ) : (
+                                            <UsdAmount value={requestedAmountInUsd} />
+                                        )}
                                     </p>
                                 </>
                             )}
@@ -111,10 +112,28 @@ const Summary: FC<AtomicSummaryProps> = ({ sourceCurrency, destinationCurrency, 
                             receiveAmount && (
                                 <div className="flex flex-col items-end w-full col-start-6 col-span-5 min-w-0">
                                     <p className="text-primary-text text-xl leading-6 h-6 font-normal flex items-center justify-end min-w-0 w-full">
-                                        {isUsdMode ? recvUsd : recvToken}
+                                        {isUsdMode ? (
+                                            <UsdAmount value={receiveAmountInUsd} />
+                                        ) : (
+                                            <TokenAmount
+                                                amount={receiveAmountNum}
+                                                decimals={destinationCurrency.decimals}
+                                                maxFractionDigits={maxFractionDigits}
+                                                symbol={destinationCurrency.symbol}
+                                            />
+                                        )}
                                     </p>
                                     <p className="text-secondary-text text-sm leading-5 flex items-center gap-1 font-medium">
-                                        {isUsdMode ? recvToken : recvUsd}
+                                        {isUsdMode ? (
+                                            <TokenAmount
+                                                amount={receiveAmountNum}
+                                                decimals={destinationCurrency.decimals}
+                                                maxFractionDigits={maxFractionDigits}
+                                                symbol={destinationCurrency.symbol}
+                                            />
+                                        ) : (
+                                            <UsdAmount value={receiveAmountInUsd} />
+                                        )}
                                     </p>
                                 </div>
                             )


### PR DESCRIPTION
- Mirror layerswap's primary/secondary swap on isUsdMode for both send/receive rows
- Wrap truncated token amounts in MobileTooltip showing full value on hover/tap
- Apply the 8/12 fraction-digit cap to send side so it truncates symmetrically with receive
- Restyle MobileTooltip's mobile popover to match the desktop tooltip pill