### PR TITLE
refactor(blockchains): split transaction builders from executors

### DIFF
--- a/.claude/rules/chain-integration.md
+++ b/.claude/rules/chain-integration.md
@@ -25,9 +25,13 @@ packages/blockchains/{chain}/
 │   │   │   ├── getTransaction.ts
 │   │   │   └── recoverSwap.ts
 │   │   └── wallet/
-│   │       ├── userLock.ts      # Full transaction building + sending (no separate builder file)
+│   │       ├── userLock.ts             # Executor — orchestrates build + simulate + send
+│   │       ├── buildUserLockTx.ts      # Pure builder — params → TransactionRequest
 │   │       ├── refund.ts
-│   │       └── redeemSolver.ts
+│   │       ├── buildRefundTx.ts
+│   │       ├── redeemSolver.ts
+│   │       ├── buildRedeemSolverTx.ts
+│   │       └── buildApproveTx.ts       # If the chain has an ERC20-like allowance flow
 │   ├── index.ts            # Registration + public exports
 │   ├── types.ts            # Signer interface + client config types
 │   ├── constants.ts        # Chain-specific constants (zero addresses, fee limits, etc.)
@@ -50,7 +54,10 @@ packages/blockchains/{chain}/
 - Each read/write method lives in its own file under `client/public/` or `client/wallet/`
 - `resolveUserLock()` is co-located in `getUserLockDetails.ts`, `resolveSolverLock()` in `getSolverLockDetails.ts` — exported for testing
 - `pickEventDerivedData()` is co-located in `getUserLockDetails.ts` (EVM/Tron) or `client/helpers.ts` (Starknet)
-- Transaction building logic lives directly in the wallet method files — no separate `transactionBuilder.ts`
+- Each write method has a **paired builder file** (`build{Method}Tx.ts`) and an **executor file** (`{method}.ts`):
+  - The **builder** is a pure synchronous function: takes params, returns a chain-specific `TransactionRequest` (e.g., `EvmTransactionRequest = { to, data, value?, chainId? }`). No RPC, no signer.
+  - The **executor** is a thin orchestrator that consumes the builder, performs simulation/preflight reads, and sends via the signer.
+  - Builders are exposed as public methods on the wallet client (`buildUserLockTx`, `buildRefundTx`, `buildRedeemSolverTx`, plus `buildApproveTx` if the chain uses ERC20-style allowances) so integrators can sign/submit via their own infra.
 - Shared utilities (`hexToUint8Array`, `encoder`, etc.) go in `src/utils.ts`
 
 ---
@@ -236,7 +243,13 @@ Chain implementations only need to implement the single-node abstract method `ge
 
 ## 5. Write Operation Patterns
 
-Each write method lives in its own file under `client/wallet/`. Transaction building and sending are in the **same file** — no separate `transactionBuilder.ts`.
+Each write method is split into two files under `client/wallet/`: a **pure builder** (`build{Method}Tx.ts`) that returns a chain-specific `TransactionRequest`, and an **executor** (`{method}.ts`) that consumes the builder, simulates, and sends via the signer.
+
+### Builder/executor split
+
+- **Builder**: synchronous, pure. Inputs are the method's params; output is `{ to, data, value?, chainId? }` (chain-specific shape). No RPC reads, no signer access. Exposed as a public method on the wallet client.
+- **Executor**: async. Calls the builder, performs any preflight (allowance check via a public-client read method, simulation via `eth_call` or equivalent), then submits via the signer. Returns the same shape as before (e.g. `AtomicResult` for `userLock`, tx hash for `refund`/`redeemSolver`).
+- **ERC20-style allowance** (if the chain has it): use a paired `buildApproveTx` builder plus a public-client read like `getErc20Allowance`. The executor decides whether to issue an approve before the lock — builders never do that themselves.
 
 ### userLock (`client/wallet/userLock.ts`)
 
@@ -442,6 +455,7 @@ The `{namespace}` is the chain identifier used in the registry (e.g., `'eip155'`
 - `{Chain}HTLCPublicClientConfig` — public client config type
 - `{Chain}HTLCWalletClientConfig` — wallet client config type
 - `{Chain}Signer` — signer type
+- `{Chain}TransactionRequest` — built/unsigned transaction request type returned by builders
 - `deriveKeyFrom{Chain}...` — key derivation function
 - Any chain-specific wallet interface types needed by consumers
 
@@ -590,10 +604,12 @@ export const ZERO_ADDRESS = '0x000...'     // Chain's empty/zero address represe
   - [ ] `getSolverLockDetails.ts` — includes exported `resolveSolverLock()`
   - [ ] `getTransaction.ts`
   - [ ] `recoverSwap.ts`
-- [ ] Each write method in its own file under `client/wallet/`:
-  - [ ] `userLock.ts` — full transaction building + sending (no separate builder file)
-  - [ ] `refund.ts`
-  - [ ] `redeemSolver.ts`
+- [ ] Each write method split into a paired builder + executor under `client/wallet/`:
+  - [ ] `userLock.ts` (executor) + `buildUserLockTx.ts` (pure builder)
+  - [ ] `refund.ts` (executor) + `buildRefundTx.ts` (pure builder)
+  - [ ] `redeemSolver.ts` (executor) + `buildRedeemSolverTx.ts` (pure builder)
+  - [ ] `buildApproveTx.ts` + `getErc20Allowance.ts` (under `client/public/`) if the chain has ERC20-like allowances
+  - [ ] Expose all builders as public methods on the wallet client
 - [ ] Count-then-loop pattern in `getSolverLockDetails` (1-indexed)
 - [ ] `getTransaction(txHash)` — non-blocking, try/catch returning `null`, all three statuses
 - [ ] Set `this.consensusOptions` in constructor if chain needs non-default quorum

--- a/apps/app/lib/balances/providers/starknetBalanceProvider.ts
+++ b/apps/app/lib/balances/providers/starknetBalanceProvider.ts
@@ -32,10 +32,19 @@ export class StarknetBalanceProvider extends BalanceProvider {
                 const erc20 = new Contract({ abi: Erc20Abi, address: token.contract, providerOrAccount: provider });
                 const balanceResult = await erc20.balanceOf(address);
 
+                const rawBalance: bigint =
+                    typeof balanceResult === 'bigint'
+                        ? balanceResult
+                        : balanceResult?.balance !== undefined
+                            ? (typeof balanceResult.balance === 'bigint'
+                                ? balanceResult.balance
+                                : uint256.uint256ToBN(balanceResult.balance))
+                            : uint256.uint256ToBN(balanceResult);
+
                 const balance = {
                     network: network.caip2Id,
                     token: token.symbol,
-                    amount: Number(formatUnits(BigInt(balanceResult), token.decimals)),
+                    amount: Number(formatUnits(rawBalance, token.decimals)),
                     request_time: new Date().toJSON(),
                     decimals: token.decimals,
                     isNativeCurrency: false,

--- a/apps/app/lib/gases/providers/solanaGasProvider.ts
+++ b/apps/app/lib/gases/providers/solanaGasProvider.ts
@@ -106,7 +106,7 @@ const userLockTransactionBuilder = async (params: UserLockParams): Promise<Trans
     const { connection, program, walletPublicKey } = params
 
     if (!walletPublicKey) throw new Error("Wallet not connected")
-    if (!params.srcSolverAddress) throw new Error("No LP address")
+    if (!params.srcSolverAddress) throw new Error("No Solver address")
     if (!params.nonce) throw new Error("No nonce")
     if (!params.solverData) throw new Error("No solver data")
 

--- a/packages/blockchains/aztec/src/client/WalletClient.ts
+++ b/packages/blockchains/aztec/src/client/WalletClient.ts
@@ -5,11 +5,14 @@ import type {
     RedeemSolverParams,
     AtomicResult,
 } from '@train-protocol/sdk'
-import type { AztecHTLCWalletClientConfig, AztecSigner } from '../types'
+import type { AztecHTLCWalletClientConfig, AztecSigner, AztecTransactionRequest } from '../types'
 import { AztecHTLCPublicClient } from './PublicClient'
 import { userLock } from './wallet/userLock'
 import { refund } from './wallet/refund'
 import { redeemSolver } from './wallet/redeemSolver'
+import { buildUserLockTx } from './wallet/buildUserLockTx'
+import { buildRefundTx } from './wallet/buildRefundTx'
+import { buildRedeemSolverTx } from './wallet/buildRedeemSolverTx'
 
 export class AztecHTLCWalletClient extends AztecHTLCPublicClient implements IHTLCWalletClient {
     declare protected readonly signer: AztecSigner
@@ -30,5 +33,22 @@ export class AztecHTLCWalletClient extends AztecHTLCPublicClient implements IHTL
 
     async redeemSolver(params: RedeemSolverParams): Promise<string> {
         return redeemSolver(this.signer, this.rpcUrl, params, this.getNode())
+    }
+
+    // ── Transaction Builders ──────────────────────────────────────────
+    // Return prepared `ContractFunctionInteraction`s ready to be batched
+    // and submitted. Registering Train/Token contracts on the wallet is a
+    // side effect — that's required by Aztec before `.at(...)` works.
+
+    async buildUserLockTx(params: UserLockParams): Promise<AztecTransactionRequest[]> {
+        return buildUserLockTx(this.signer, this.rpcUrl, params, this.getNode())
+    }
+
+    async buildRefundTx(params: RefundParams): Promise<AztecTransactionRequest> {
+        return buildRefundTx(this.signer, params, this.getNode())
+    }
+
+    async buildRedeemSolverTx(params: RedeemSolverParams): Promise<AztecTransactionRequest> {
+        return buildRedeemSolverTx(this.signer, this.rpcUrl, params, this.getNode())
     }
 }

--- a/packages/blockchains/aztec/src/client/wallet/buildRedeemSolverTx.ts
+++ b/packages/blockchains/aztec/src/client/wallet/buildRedeemSolverTx.ts
@@ -1,0 +1,37 @@
+import { AztecAddress } from '@aztec/aztec.js/addresses'
+import type { AztecNode } from '@aztec/aztec.js/node'
+import { hexToBytes } from '@train-protocol/sdk'
+import type { RedeemSolverParams } from '@train-protocol/sdk'
+import { TokenContract } from '../../artifacts/Token'
+import type { AztecSigner, AztecTransactionRequest } from '../../types'
+import { getContractInstance } from '../helpers'
+
+export async function buildRedeemSolverTx(
+    signer: AztecSigner,
+    rpcUrl: string,
+    params: RedeemSolverParams,
+    node: AztecNode,
+): Promise<AztecTransactionRequest> {
+    const { contract, node: contractNode } = await getContractInstance(params.contractAddress, signer, node)
+
+    if (params.destinationAsset?.contract) {
+        const tokenAddress = AztecAddress.fromString(params.destinationAsset.contract)
+        const tokenInstance = await contractNode.getContract(tokenAddress)
+        if (!tokenInstance) {
+            throw new Error(
+                `Token contract not found at ${tokenAddress.toString()} on node ${rpcUrl}`,
+            )
+        }
+        await signer.wallet.registerContract(tokenInstance, TokenContract.artifact)
+        await signer.wallet.registerSender(AztecAddress.fromString(params.contractAddress))
+    }
+
+    const hashlockBytes = hexToBytes(params.id, 32)
+
+    const secretHex = typeof params.secret === 'bigint'
+        ? '0x' + params.secret.toString(16).padStart(64, '0')
+        : String(params.secret)
+    const secretBytes = hexToBytes(secretHex, 32)
+
+    return contract.methods.redeem_solver(hashlockBytes, BigInt(params.index ?? 1), secretBytes)
+}

--- a/packages/blockchains/aztec/src/client/wallet/buildRefundTx.ts
+++ b/packages/blockchains/aztec/src/client/wallet/buildRefundTx.ts
@@ -1,0 +1,15 @@
+import type { AztecNode } from '@aztec/aztec.js/node'
+import { hexToBytes } from '@train-protocol/sdk'
+import type { RefundParams } from '@train-protocol/sdk'
+import type { AztecSigner, AztecTransactionRequest } from '../../types'
+import { getContractInstance } from '../helpers'
+
+export async function buildRefundTx(
+    signer: AztecSigner,
+    params: RefundParams,
+    node: AztecNode,
+): Promise<AztecTransactionRequest> {
+    const { contract } = await getContractInstance(params.contractAddress, signer, node)
+    const hashlockBytes = hexToBytes(params.id, 32)
+    return contract.methods.refund_user(hashlockBytes)
+}

--- a/packages/blockchains/aztec/src/client/wallet/buildUserLockTx.ts
+++ b/packages/blockchains/aztec/src/client/wallet/buildUserLockTx.ts
@@ -1,0 +1,87 @@
+import { AztecAddress } from '@aztec/aztec.js/addresses'
+import { SetPublicAuthwitContractInteraction } from '@aztec/aztec.js/authorization'
+import { Fr } from '@aztec/aztec.js/fields'
+import type { AztecNode } from '@aztec/aztec.js/node'
+import { parseUnits, hexToBytes } from '@train-protocol/sdk'
+import type { UserLockParams } from '@train-protocol/sdk'
+import { TokenContract } from '../../artifacts/Token'
+import { TrainContract } from '../../artifacts/Train'
+import type { AztecSigner, AztecTransactionRequest } from '../../types'
+import { strToBytes } from '../helpers'
+
+/**
+ * Build the pair of `ContractFunctionInteraction`s required for a user lock:
+ *   - public-authwit authorization for the token transfer
+ *   - the `user_lock` call itself
+ *
+ * Both must be sent together via `BatchCall` (one wallet confirmation).
+ * Registers the Train + Token contracts on the wallet as a side effect —
+ * Aztec requires this before `.at(...)` can be called.
+ */
+export async function buildUserLockTx(
+    signer: AztecSigner,
+    rpcUrl: string,
+    params: UserLockParams,
+    node: AztecNode,
+): Promise<AztecTransactionRequest[]> {
+    const accounts = await signer.wallet.getAccounts()
+    const senderAddress = accounts[0].item
+
+    const trainAddress = AztecAddress.fromString(params.atomicContract)
+    const tokenAddress = AztecAddress.fromString(params.sourceAsset.contract!)
+
+    const trainInstance = await node.getContract(trainAddress)
+    if (!trainInstance) throw new Error('Train contract not found')
+    await signer.wallet.registerContract(trainInstance, TrainContract.artifact)
+    const train = TrainContract.at(trainAddress, signer.wallet)
+
+    const tokenInstance = await node.getContract(tokenAddress)
+    if (!tokenInstance) {
+        throw new Error(
+            `Token contract not found at ${tokenAddress.toString()} on node ${rpcUrl}`,
+        )
+    }
+    await signer.wallet.registerContract(tokenInstance, TokenContract.artifact)
+    const token = TokenContract.at(tokenAddress, signer.wallet)
+
+    const amount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
+
+    const transferNonce = Fr.random()
+    const publicAction = token.methods.transfer_public_to_public(
+        senderAddress,
+        trainAddress,
+        amount,
+        transferNonce,
+    )
+
+    const setPublicAuthwit = await SetPublicAuthwitContractInteraction.create(
+        signer.wallet,
+        senderAddress,
+        { caller: trainAddress, action: publicAction },
+        true,
+    )
+
+    const userLockInteraction = train.methods.user_lock(
+        hexToBytes(params.hashlock, 32),
+        amount,
+        transferNonce,
+        params.rewardAmount ? BigInt(params.rewardAmount) : 0n,
+        params.timelockDelta ?? 40,
+        params.rewardTimelockDelta ?? 0,
+        params.quoteExpiry,
+        senderAddress,
+        AztecAddress.fromString(params.srcSolverAddress),
+        tokenAddress,
+        strToBytes(params.rewardToken || '', 90),
+        strToBytes(params.rewardRecipient || '', 90),
+        strToBytes(params.sourceChain, 30),
+        strToBytes(params.destinationChain, 30),
+        strToBytes(params.destinationAddress, 90),
+        BigInt(params.destinationAmount),
+        strToBytes(params.destinationAsset.contract, 90),
+        strToBytes(params.nonce.toString() ?? '', 256),
+        strToBytes(params.solverData ?? '', 256),
+    )
+
+    return [setPublicAuthwit, userLockInteraction]
+}

--- a/packages/blockchains/aztec/src/client/wallet/redeemSolver.ts
+++ b/packages/blockchains/aztec/src/client/wallet/redeemSolver.ts
@@ -1,10 +1,7 @@
-import { AztecAddress } from '@aztec/aztec.js/addresses'
 import type { AztecNode } from '@aztec/aztec.js/node'
-import { hexToBytes } from '@train-protocol/sdk'
 import type { RedeemSolverParams } from '@train-protocol/sdk'
-import { TokenContract } from '../../artifacts/Token'
 import type { AztecSigner } from '../../types'
-import { getContractInstance } from '../helpers'
+import { buildRedeemSolverTx } from './buildRedeemSolverTx'
 
 export async function redeemSolver(
     signer: AztecSigner,
@@ -13,38 +10,14 @@ export async function redeemSolver(
     node: AztecNode,
 ): Promise<string> {
     try {
-        const { contract, node: contractNode } = await getContractInstance(params.contractAddress, signer, node)
+        const interaction = await buildRedeemSolverTx(signer, rpcUrl, params, node)
         const accounts = await signer.wallet.getAccounts()
         const senderAddress = accounts[0].item
 
-        // Register Token contract if provided (needed for redeem)
-        if (params.destinationAsset?.contract) {
-            const tokenAddress = AztecAddress.fromString(params.destinationAsset.contract)
-            const tokenInstance = await contractNode.getContract(tokenAddress)
-            if (!tokenInstance) {
-                throw new Error(
-                    `Token contract not found at ${tokenAddress.toString()} on node ${rpcUrl}`,
-                )
-            }
-            await signer.wallet.registerContract(tokenInstance, TokenContract.artifact)
-            await signer.wallet.registerSender(AztecAddress.fromString(params.contractAddress))
-        }
-
-        const hashlockBytes = hexToBytes(params.id, 32)
-
-        const secretHex = typeof params.secret === 'bigint'
-            ? '0x' + params.secret.toString(16).padStart(64, '0')
-            : String(params.secret)
-        const secretBytes = hexToBytes(secretHex, 32)
-
-        const txTimeout = 120000
-
-        const tx = await contract.methods
-            .redeem_solver(hashlockBytes, BigInt(params.index ?? 1), secretBytes)
-            .send({
-                from: senderAddress,
-                wait: { timeout: txTimeout, dontThrowOnRevert: true },
-            })
+        const tx = await interaction.send({
+            from: senderAddress,
+            wait: { timeout: 120000, dontThrowOnRevert: true },
+        })
 
         if (tx.receipt.hasExecutionReverted()) {
             throw new Error(`redeem_solver reverted: ${tx.receipt.error ?? 'unknown error'}`)

--- a/packages/blockchains/aztec/src/client/wallet/refund.ts
+++ b/packages/blockchains/aztec/src/client/wallet/refund.ts
@@ -1,8 +1,7 @@
 import type { AztecNode } from '@aztec/aztec.js/node'
-import { hexToBytes } from '@train-protocol/sdk'
 import type { RefundParams } from '@train-protocol/sdk'
 import type { AztecSigner } from '../../types'
-import { getContractInstance } from '../helpers'
+import { buildRefundTx } from './buildRefundTx'
 
 export async function refund(
     signer: AztecSigner,
@@ -10,19 +9,14 @@ export async function refund(
     node: AztecNode,
 ): Promise<string> {
     try {
-        const { contract } = await getContractInstance(params.contractAddress, signer, node)
+        const interaction = await buildRefundTx(signer, params, node)
         const accounts = await signer.wallet.getAccounts()
         const senderAddress = accounts[0].item
 
-        const hashlockBytes = hexToBytes(params.id, 32)
-        const txTimeout = 120000
-
-        const tx = await contract.methods
-            .refund_user(hashlockBytes)
-            .send({
-                from: senderAddress,
-                wait: { timeout: txTimeout, dontThrowOnRevert: true },
-            })
+        const tx = await interaction.send({
+            from: senderAddress,
+            wait: { timeout: 120000, dontThrowOnRevert: true },
+        })
 
         if (tx.receipt.hasExecutionReverted()) {
             throw new Error(`refund_user reverted: ${tx.receipt.error ?? 'unknown error'}`)

--- a/packages/blockchains/aztec/src/client/wallet/userLock.ts
+++ b/packages/blockchains/aztec/src/client/wallet/userLock.ts
@@ -1,14 +1,8 @@
-import { AztecAddress } from '@aztec/aztec.js/addresses'
-import { SetPublicAuthwitContractInteraction } from '@aztec/aztec.js/authorization'
 import { BatchCall } from '@aztec/aztec.js/contracts'
-import { Fr } from '@aztec/aztec.js/fields'
 import type { AztecNode } from '@aztec/aztec.js/node'
-import { parseUnits, hexToBytes } from '@train-protocol/sdk'
 import type { UserLockParams, AtomicResult } from '@train-protocol/sdk'
-import { TokenContract } from '../../artifacts/Token'
-import { TrainContract } from '../../artifacts/Train'
 import type { AztecSigner } from '../../types'
-import { strToBytes } from '../helpers'
+import { buildUserLockTx } from './buildUserLockTx'
 
 export async function userLock(
     signer: AztecSigner,
@@ -17,70 +11,11 @@ export async function userLock(
     node: AztecNode,
 ): Promise<AtomicResult> {
     try {
+        const interactions = await buildUserLockTx(signer, rpcUrl, params, node)
         const accounts = await signer.wallet.getAccounts()
         const senderAddress = accounts[0].item
 
-        const trainAddress = AztecAddress.fromString(params.atomicContract)
-        const tokenAddress = AztecAddress.fromString(params.sourceAsset.contract!)
-
-        // Register Train contract
-        const trainInstance = await node.getContract(trainAddress)
-        if (!trainInstance) throw new Error('Train contract not found')
-        await signer.wallet.registerContract(trainInstance, TrainContract.artifact)
-        const train = TrainContract.at(trainAddress, signer.wallet)
-
-        // Register Token contract
-        const tokenInstance = await node.getContract(tokenAddress)
-        if (!tokenInstance) {
-            throw new Error(
-                `Token contract not found at ${tokenAddress.toString()} on node ${rpcUrl}`,
-            )
-        }
-        await signer.wallet.registerContract(tokenInstance, TokenContract.artifact)
-        const token = TokenContract.at(tokenAddress, signer.wallet)
-
-        const amount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
-
-        // Authorize public token transfer
-        const transferNonce = Fr.random()
-        const publicAction = token.methods.transfer_public_to_public(
-            senderAddress,
-            trainAddress,
-            amount,
-            transferNonce,
-        )
-
-        const setPublicAuthwit = await SetPublicAuthwitContractInteraction.create(
-            signer.wallet,
-            senderAddress,
-            { caller: trainAddress, action: publicAction },
-            true,
-        )
-
-        // Batch authwit + user_lock into a single transaction (one wallet confirmation)
-        const userLockInteraction = train.methods.user_lock(
-            hexToBytes(params.hashlock, 32),
-            amount,
-            transferNonce,
-            params.rewardAmount ? BigInt(params.rewardAmount) : 0n,
-            params.timelockDelta ?? 40,
-            params.rewardTimelockDelta ?? 0,
-            params.quoteExpiry,
-            senderAddress,
-            AztecAddress.fromString(params.srcSolverAddress),
-            tokenAddress,
-            strToBytes(params.rewardToken || '', 90),
-            strToBytes(params.rewardRecipient || '', 90),
-            strToBytes(params.sourceChain, 30),
-            strToBytes(params.destinationChain, 30),
-            strToBytes(params.destinationAddress, 90),
-            BigInt(params.destinationAmount),
-            strToBytes(params.destinationAsset.contract, 90),
-            strToBytes(params.nonce.toString() ?? '', 256),
-            strToBytes(params.solverData ?? '', 256),
-        )
-
-        const batch = new BatchCall(signer.wallet, [setPublicAuthwit, userLockInteraction])
+        const batch = new BatchCall(signer.wallet, interactions)
         const txTimeout = 120000
         const tx = await batch.send({
             from: senderAddress,

--- a/packages/blockchains/aztec/src/index.ts
+++ b/packages/blockchains/aztec/src/index.ts
@@ -4,7 +4,7 @@ import { AztecHTLCPublicClient, AztecHTLCWalletClient } from './client/index'
 import { deriveKeyFromAztecWallet } from './login/index'
 
 export { AztecHTLCPublicClient, AztecHTLCWalletClient } from './client/index'
-export type { AztecHTLCPublicClientConfig, AztecHTLCWalletClientConfig, AztecSigner } from './types'
+export type { AztecHTLCPublicClientConfig, AztecHTLCWalletClientConfig, AztecSigner, AztecTransactionRequest } from './types'
 export { deriveKeyFromAztecWallet } from './login/index'
 export type { AztecWalletLike } from './login/index'
 

--- a/packages/blockchains/aztec/src/types.ts
+++ b/packages/blockchains/aztec/src/types.ts
@@ -1,5 +1,14 @@
 import type { Wallet } from '@aztec/aztec.js/wallet'
+import type { ContractFunctionInteraction } from '@aztec/aztec.js/contracts'
 import type { AztecWalletLike } from './login/wallet-sign.js'
+
+/**
+ * A built Aztec contract function interaction. Output of the builder methods.
+ * `buildUserLockTx` returns an array `[authwit, userLock]` to be batched in
+ * a single transaction; `buildRefundTx` / `buildRedeemSolverTx` each return
+ * a single interaction.
+ */
+export type AztecTransactionRequest = ContractFunctionInteraction
 
 declare module '@train-protocol/sdk' {
     interface HTLCPublicClientConfigMap {

--- a/packages/blockchains/aztec/src/types.ts
+++ b/packages/blockchains/aztec/src/types.ts
@@ -17,6 +17,9 @@ declare module '@train-protocol/sdk' {
     interface HTLCWalletClientConfigMap {
         aztec: AztecHTLCWalletClientConfig
     }
+    interface HTLCTransactionRequestMap {
+        aztec: AztecTransactionRequest
+    }
 }
 
 declare module '@train-protocol/auth' {

--- a/packages/blockchains/evm/src/__tests__/builders.test.ts
+++ b/packages/blockchains/evm/src/__tests__/builders.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { AbiFunction } from 'ox'
+import type { UserLockParams, RefundParams, RedeemSolverParams, Token } from '@train-protocol/sdk'
+import { buildUserLockTx } from '../client/wallet/buildUserLockTx'
+import { buildRefundTx } from '../client/wallet/buildRefundTx'
+import { buildRedeemSolverTx } from '../client/wallet/buildRedeemSolverTx'
+import { buildApproveTx } from '../client/wallet/buildApproveTx'
+import { htlcFunctions, erc20Functions } from '../abi'
+import { ZERO_ADDRESS } from '../constants'
+
+const hashlock = '0x' + 'ab'.repeat(32)
+const atomicContract = '0x1111111111111111111111111111111111111111'
+const sourceAddress = '0x2222222222222222222222222222222222222222'
+const srcSolverAddress = '0x3333333333333333333333333333333333333333'
+const erc20Token = '0x4444444444444444444444444444444444444444'
+
+const nativeAsset = { symbol: 'ETH', contract: ZERO_ADDRESS, decimals: 18 } as unknown as Token
+const erc20Asset = { symbol: 'USDC', contract: erc20Token, decimals: 6 } as unknown as Token
+const destinationAsset = {
+    symbol: 'USDC',
+    contract: '0x5555555555555555555555555555555555555555',
+    decimals: 6,
+} as unknown as Token
+
+function makeUserLockParams(overrides: Partial<UserLockParams> = {}): UserLockParams {
+    return {
+        sourceChain: 'eip155:11155111',
+        destinationChain: 'eip155:84532',
+        amount: '1.5',
+        destinationAmount: '1500000',
+        sourceAsset: nativeAsset,
+        destinationAsset,
+        srcSolverAddress,
+        destSolverAddress: srcSolverAddress,
+        atomicContract,
+        sourceAddress,
+        destinationAddress: sourceAddress,
+        quoteExpiry: 1700000000,
+        timelockDelta: 3600,
+        hashlock,
+        nonce: 1700000000000,
+        ...overrides,
+    }
+}
+
+describe('buildUserLockTx', () => {
+    it('returns native value for native asset and decodes via userLock ABI', () => {
+        const tx = buildUserLockTx(makeUserLockParams())
+
+        expect(tx.to).toBe(atomicContract)
+        expect(tx.value).toBe(1500000000000000000n) // 1.5 ETH in wei
+        // Round-trips through the matching ABI without throwing
+        expect(() =>
+            AbiFunction.decodeData(htlcFunctions.userLock, tx.data as `0x${string}`),
+        ).not.toThrow()
+    })
+
+    it('omits value for ERC20 source asset', () => {
+        const tx = buildUserLockTx(makeUserLockParams({ sourceAsset: erc20Asset, amount: '10' }))
+
+        expect(tx.value).toBeUndefined()
+        expect(() =>
+            AbiFunction.decodeData(htlcFunctions.userLock, tx.data as `0x${string}`),
+        ).not.toThrow()
+    })
+
+    it('is deterministic for identical params', () => {
+        const a = buildUserLockTx(makeUserLockParams())
+        const b = buildUserLockTx(makeUserLockParams())
+        expect(a).toEqual(b)
+    })
+})
+
+describe('buildRefundTx', () => {
+    it('encodes refundUser with the lock id', () => {
+        const params: RefundParams = {
+            chainId: null,
+            contractAddress: atomicContract,
+            id: hashlock,
+            sourceAsset: nativeAsset,
+        }
+        const tx = buildRefundTx(params)
+
+        expect(tx.to).toBe(atomicContract)
+        expect(tx.value).toBeUndefined()
+
+        const decoded = AbiFunction.decodeData(
+            htlcFunctions.refundUser,
+            tx.data as `0x${string}`,
+        ) as readonly [`0x${string}`]
+        expect(decoded[0]).toBe(hashlock)
+    })
+})
+
+describe('buildRedeemSolverTx', () => {
+    it('encodes redeemSolver with id, index=1, and secret as bigint', () => {
+        const secret = '0x' + '12'.repeat(32)
+        const params: RedeemSolverParams = {
+            chainId: null,
+            contractAddress: atomicContract,
+            id: hashlock,
+            secret,
+            sourceAsset: nativeAsset,
+            destinationAddress: sourceAddress,
+            destinationAsset,
+        }
+        const tx = buildRedeemSolverTx(params)
+
+        expect(tx.to).toBe(atomicContract)
+
+        const decoded = AbiFunction.decodeData(
+            htlcFunctions.redeemSolver,
+            tx.data as `0x${string}`,
+        ) as readonly [`0x${string}`, bigint, bigint]
+        expect(decoded[0]).toBe(hashlock)
+        expect(decoded[1]).toBe(1n)
+        expect(decoded[2]).toBe(BigInt(secret))
+    })
+})
+
+describe('buildApproveTx', () => {
+    it('encodes approve(spender, amount) on the token contract', () => {
+        const tx = buildApproveTx({
+            token: erc20Token,
+            spender: atomicContract,
+            amount: 1_000_000n,
+        })
+
+        expect(tx.to).toBe(erc20Token)
+        expect(tx.value).toBeUndefined()
+
+        const decoded = AbiFunction.decodeData(
+            erc20Functions.approve,
+            tx.data as `0x${string}`,
+        ) as readonly [`0x${string}`, bigint]
+        expect(decoded[0].toLowerCase()).toBe(atomicContract.toLowerCase())
+        expect(decoded[1]).toBe(1_000_000n)
+    })
+})

--- a/packages/blockchains/evm/src/client/PublicClient.ts
+++ b/packages/blockchains/evm/src/client/PublicClient.ts
@@ -14,6 +14,7 @@ import { getUserLockDetails } from './public/getUserLockDetails.js'
 import { getSolverLockDetails } from './public/getSolverLockDetails.js'
 import { recoverSwap } from './public/recoverSwap.js'
 import { getTransaction } from './public/getTransaction.js'
+import { getErc20Allowance } from './public/getErc20Allowance.js'
 
 export class EvmHTLCPublicClient extends HTLCPublicClient {
     protected rpc: JsonRpcClient
@@ -37,5 +38,9 @@ export class EvmHTLCPublicClient extends HTLCPublicClient {
 
     async getTransaction(txHash: string): Promise<TransactionInfo | null> {
         return getTransaction(this.rpc, txHash)
+    }
+
+    async getErc20Allowance(token: string, owner: string, spender: string): Promise<bigint> {
+        return getErc20Allowance(this.rpc, token, owner, spender)
     }
 }

--- a/packages/blockchains/evm/src/client/WalletClient.ts
+++ b/packages/blockchains/evm/src/client/WalletClient.ts
@@ -5,11 +5,15 @@ import type {
     RedeemSolverParams,
     AtomicResult,
 } from '@train-protocol/sdk'
-import type { EvmHTLCWalletClientConfig, EvmSigner } from '../types.js'
+import type { EvmHTLCWalletClientConfig, EvmSigner, EvmTransactionRequest } from '../types.js'
 import { EvmHTLCPublicClient } from './PublicClient.js'
 import { userLock } from './wallet/userLock.js'
 import { refund } from './wallet/refund.js'
 import { redeemSolver } from './wallet/redeemSolver.js'
+import { buildUserLockTx } from './wallet/buildUserLockTx.js'
+import { buildRefundTx } from './wallet/buildRefundTx.js'
+import { buildRedeemSolverTx } from './wallet/buildRedeemSolverTx.js'
+import { buildApproveTx, type BuildApproveTxParams } from './wallet/buildApproveTx.js'
 
 export class EvmHTLCWalletClient extends EvmHTLCPublicClient implements IHTLCWalletClient {
     private signer: EvmSigner
@@ -29,5 +33,26 @@ export class EvmHTLCWalletClient extends EvmHTLCPublicClient implements IHTLCWal
 
     async redeemSolver(params: RedeemSolverParams): Promise<string> {
         return redeemSolver(this.rpc, this.signer, params)
+    }
+
+    // ── Transaction Builders ──────────────────────────────────────────
+    // Pure calldata + tx-request constructors. No RPC, no signer.
+    // Useful for integrators who want to sign/submit via their own infra
+    // (Safe SDK, smart accounts, custom relayers, batched txs).
+
+    buildUserLockTx(params: UserLockParams): EvmTransactionRequest {
+        return buildUserLockTx(params)
+    }
+
+    buildRefundTx(params: RefundParams): EvmTransactionRequest {
+        return buildRefundTx(params)
+    }
+
+    buildRedeemSolverTx(params: RedeemSolverParams): EvmTransactionRequest {
+        return buildRedeemSolverTx(params)
+    }
+
+    buildApproveTx(params: BuildApproveTxParams): EvmTransactionRequest {
+        return buildApproveTx(params)
     }
 }

--- a/packages/blockchains/evm/src/client/public/getErc20Allowance.ts
+++ b/packages/blockchains/evm/src/client/public/getErc20Allowance.ts
@@ -1,0 +1,15 @@
+import { AbiFunction } from 'ox'
+import { erc20Functions } from '../../abi.js'
+import type { JsonRpcClient } from '../../rpc.js'
+import { hex } from '../../utils.js'
+
+export async function getErc20Allowance(
+    rpc: JsonRpcClient,
+    token: string,
+    owner: string,
+    spender: string,
+): Promise<bigint> {
+    const data = AbiFunction.encodeData(erc20Functions.allowance, [hex(owner), hex(spender)])
+    const raw = await rpc.ethCall(token, data)
+    return AbiFunction.decodeResult(erc20Functions.allowance, hex(raw))
+}

--- a/packages/blockchains/evm/src/client/wallet/buildApproveTx.ts
+++ b/packages/blockchains/evm/src/client/wallet/buildApproveTx.ts
@@ -1,0 +1,18 @@
+import { AbiFunction } from 'ox'
+import { erc20Functions } from '../../abi.js'
+import type { EvmTransactionRequest } from '../../types.js'
+import { hex } from '../../utils.js'
+
+export interface BuildApproveTxParams {
+    token: string
+    spender: string
+    amount: bigint
+}
+
+export function buildApproveTx(params: BuildApproveTxParams): EvmTransactionRequest {
+    const data = AbiFunction.encodeData(erc20Functions.approve, [
+        hex(params.spender),
+        params.amount,
+    ])
+    return { to: params.token, data }
+}

--- a/packages/blockchains/evm/src/client/wallet/buildRedeemSolverTx.ts
+++ b/packages/blockchains/evm/src/client/wallet/buildRedeemSolverTx.ts
@@ -1,0 +1,14 @@
+import { AbiFunction } from 'ox'
+import type { RedeemSolverParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { EvmTransactionRequest } from '../../types.js'
+import { hex } from '../../utils.js'
+
+export function buildRedeemSolverTx(params: RedeemSolverParams): EvmTransactionRequest {
+    const data = AbiFunction.encodeData(htlcFunctions.redeemSolver, [
+        hex(params.id),
+        1n,
+        BigInt(params.secret),
+    ])
+    return { to: params.contractAddress, data }
+}

--- a/packages/blockchains/evm/src/client/wallet/buildRefundTx.ts
+++ b/packages/blockchains/evm/src/client/wallet/buildRefundTx.ts
@@ -1,0 +1,10 @@
+import { AbiFunction } from 'ox'
+import type { RefundParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { EvmTransactionRequest } from '../../types.js'
+import { hex } from '../../utils.js'
+
+export function buildRefundTx(params: RefundParams): EvmTransactionRequest {
+    const data = AbiFunction.encodeData(htlcFunctions.refundUser, [hex(params.id)])
+    return { to: params.contractAddress, data }
+}

--- a/packages/blockchains/evm/src/client/wallet/buildUserLockTx.ts
+++ b/packages/blockchains/evm/src/client/wallet/buildUserLockTx.ts
@@ -1,0 +1,47 @@
+import { AbiFunction } from 'ox'
+import { parseUnits, toHex32 } from '@train-protocol/sdk'
+import type { UserLockParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { EvmTransactionRequest } from '../../types.js'
+import { ZERO_ADDRESS } from '../../constants.js'
+import { hex } from '../../utils.js'
+
+export function buildUserLockTx(params: UserLockParams): EvmTransactionRequest {
+    const { sourceAsset } = params
+
+    const parsedAmount = parseUnits(params.amount.toString(), sourceAsset.decimals)
+    const tokenAddress = sourceAsset.contract || ZERO_ADDRESS
+    const isNativeToken = !sourceAsset.contract || sourceAsset.contract === ZERO_ADDRESS
+
+    const userData = toHex32(BigInt(params.nonce))
+    const data = AbiFunction.encodeData(htlcFunctions.userLock, [
+        {
+            hashlock: hex(params.hashlock),
+            amount: parsedAmount,
+            rewardAmount: params.rewardAmount || 0n,
+            timelockDelta: params.timelockDelta,
+            rewardTimelockDelta: params.rewardTimelockDelta ?? 0,
+            quoteExpiry: params.quoteExpiry,
+            sender: hex(params.sourceAddress),
+            recipient: hex(params.srcSolverAddress),
+            token: hex(tokenAddress),
+            rewardToken: params.rewardToken ?? '',
+            rewardRecipient: params.rewardRecipient ?? '',
+            srcChain: params.sourceChain || '',
+        },
+        {
+            dstChain: params.destinationChain,
+            dstAddress: params.destinationAddress,
+            dstAmount: params.destinationAmount,
+            dstToken: params.destinationAsset.contract,
+        },
+        hex(userData),
+        hex(params.solverData || '0x'),
+    ])
+
+    return {
+        to: params.atomicContract,
+        data,
+        value: isNativeToken ? parsedAmount : undefined,
+    }
+}

--- a/packages/blockchains/evm/src/client/wallet/redeemSolver.ts
+++ b/packages/blockchains/evm/src/client/wallet/redeemSolver.ts
@@ -1,28 +1,20 @@
-import { AbiFunction } from 'ox'
 import type { RedeemSolverParams } from '@train-protocol/sdk'
-import { htlcFunctions } from '../../abi.js'
 import type { JsonRpcClient } from '../../rpc.js'
 import type { EvmSigner } from '../../types.js'
-import { decodeContractError, hex } from '../../utils.js'
+import { decodeContractError } from '../../utils.js'
+import { buildRedeemSolverTx } from './buildRedeemSolverTx.js'
 
 export async function redeemSolver(
     rpc: JsonRpcClient,
     signer: EvmSigner,
     params: RedeemSolverParams,
 ): Promise<string> {
-    const { id, contractAddress, secret, destinationAddress } = params
-
-    const caller = destinationAddress ?? signer.address
-    const calldata = AbiFunction.encodeData(htlcFunctions.redeemSolver, [
-        hex(id),
-        1n,
-        BigInt(secret),
-    ])
+    const caller = params.destinationAddress ?? signer.address
+    const tx = buildRedeemSolverTx(params)
 
     try {
-        await rpc.ethCall(contractAddress, calldata, caller)
-
-        return signer.sendTransaction({ to: contractAddress, data: calldata })
+        await rpc.ethCall(tx.to, tx.data, caller)
+        return signer.sendTransaction(tx)
     } catch (error) {
         const errorName = decodeContractError(error)
         if (errorName) throw new Error(`Contract error: ${errorName}`)

--- a/packages/blockchains/evm/src/client/wallet/refund.ts
+++ b/packages/blockchains/evm/src/client/wallet/refund.ts
@@ -1,23 +1,19 @@
-import { AbiFunction } from 'ox'
 import type { RefundParams } from '@train-protocol/sdk'
-import { htlcFunctions } from '../../abi.js'
 import type { JsonRpcClient } from '../../rpc.js'
 import type { EvmSigner } from '../../types.js'
-import { decodeContractError, hex } from '../../utils.js'
+import { decodeContractError } from '../../utils.js'
+import { buildRefundTx } from './buildRefundTx.js'
 
 export async function refund(
     rpc: JsonRpcClient,
     signer: EvmSigner,
     params: RefundParams,
 ): Promise<string> {
-    const { id, contractAddress } = params
-
-    const calldata = AbiFunction.encodeData(htlcFunctions.refundUser, [hex(id)])
+    const tx = buildRefundTx(params)
 
     try {
-        await rpc.ethCall(contractAddress, calldata, signer.address)
-
-        return signer.sendTransaction({ to: contractAddress, data: calldata })
+        await rpc.ethCall(tx.to, tx.data, signer.address)
+        return signer.sendTransaction(tx)
     } catch (error) {
         const errorName = decodeContractError(error)
         if (errorName) throw new Error(`Contract error: ${errorName}`)

--- a/packages/blockchains/evm/src/client/wallet/userLock.ts
+++ b/packages/blockchains/evm/src/client/wallet/userLock.ts
@@ -1,73 +1,51 @@
-import { AbiFunction } from 'ox'
-import { parseUnits, toHex32 } from '@train-protocol/sdk'
+import { parseUnits } from '@train-protocol/sdk'
 import type { UserLockParams, AtomicResult } from '@train-protocol/sdk'
-import { htlcFunctions, erc20Functions } from '../../abi.js'
 import type { JsonRpcClient } from '../../rpc.js'
 import type { EvmSigner, RpcTransactionReceipt } from '../../types.js'
 import { ZERO_ADDRESS } from '../../constants.js'
-import { decodeContractError, hex } from '../../utils.js'
+import { decodeContractError } from '../../utils.js'
+import { buildUserLockTx } from './buildUserLockTx.js'
+import { buildApproveTx } from './buildApproveTx.js'
+import { getErc20Allowance } from '../public/getErc20Allowance.js'
 
 export async function userLock(
     rpc: JsonRpcClient,
     signer: EvmSigner,
     params: UserLockParams,
 ): Promise<AtomicResult> {
-    const { sourceAsset, sourceAddress } = params
-
-    const parsedAmount = parseUnits(params.amount.toString(), sourceAsset.decimals)
-    const tokenAddress = sourceAsset.contract || ZERO_ADDRESS
-    const isNativeToken = !sourceAsset.contract || sourceAsset.contract === ZERO_ADDRESS
+    const tokenAddress = params.sourceAsset.contract
+    const isNativeToken = !tokenAddress || tokenAddress === ZERO_ADDRESS
+    const parsedAmount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
 
     if (!isNativeToken) {
-        await ensureERC20Allowance(
+        const allowance = await getErc20Allowance(
             rpc,
-            signer,
-            sourceAsset.contract!,
-            sourceAddress,
+            tokenAddress!,
+            params.sourceAddress,
             params.atomicContract,
-            parsedAmount,
         )
+        if (allowance < parsedAmount) {
+            const approveTx = buildApproveTx({
+                token: tokenAddress!,
+                spender: params.atomicContract,
+                amount: parsedAmount,
+            })
+            const approveHash = await signer.sendTransaction(approveTx)
+            await waitForReceipt(rpc, approveHash)
+        }
     }
 
-    const userData = toHex32(BigInt(params.nonce))
-    const calldata = AbiFunction.encodeData(htlcFunctions.userLock, [
-        {
-            hashlock: hex(params.hashlock),
-            amount: parsedAmount,
-            rewardAmount: params.rewardAmount || 0n,
-            timelockDelta: params.timelockDelta,
-            rewardTimelockDelta: params.rewardTimelockDelta ?? 0,
-            quoteExpiry: params.quoteExpiry,
-            sender: hex(params.sourceAddress),
-            recipient: hex(params.srcSolverAddress),
-            token: hex(tokenAddress),
-            rewardToken: params.rewardToken ?? '',
-            rewardRecipient: params.rewardRecipient ?? '',
-            srcChain: params.sourceChain || '',
-        },
-        {
-            dstChain: params.destinationChain,
-            dstAddress: params.destinationAddress,
-            dstAmount: params.destinationAmount,
-            dstToken: params.destinationAsset.contract,
-        },
-        hex(userData),
-        hex(params.solverData || '0x'),
-    ])
+    const lockTx = buildUserLockTx(params)
 
     try {
         await rpc.ethCall(
-            params.atomicContract,
-            calldata,
-            sourceAddress,
-            isNativeToken ? parsedAmount : undefined,
+            lockTx.to,
+            lockTx.data,
+            params.sourceAddress,
+            lockTx.value,
         )
 
-        const hash = await signer.sendTransaction({
-            to: params.atomicContract,
-            data: calldata,
-            value: isNativeToken ? parsedAmount : undefined,
-        })
+        const hash = await signer.sendTransaction(lockTx)
 
         return { hash, hashlock: params.hashlock, nonce: params.nonce }
     } catch (error) {
@@ -76,25 +54,6 @@ export async function userLock(
         console.error('Error in userLock:', error)
         throw error
     }
-}
-
-async function ensureERC20Allowance(
-    rpc: JsonRpcClient,
-    signer: EvmSigner,
-    tokenAddress: string,
-    owner: string,
-    spender: string,
-    requiredAmount: bigint,
-): Promise<void> {
-    const allowanceData = AbiFunction.encodeData(erc20Functions.allowance, [hex(owner), hex(spender)])
-    const allowanceRaw = await rpc.ethCall(tokenAddress, allowanceData)
-    const allowance = AbiFunction.decodeResult(erc20Functions.allowance, hex(allowanceRaw))
-
-    if (allowance >= requiredAmount) return
-
-    const approveData = AbiFunction.encodeData(erc20Functions.approve, [hex(spender), requiredAmount])
-    const approveHash = await signer.sendTransaction({ to: tokenAddress, data: approveData })
-    await waitForReceipt(rpc, approveHash)
 }
 
 export async function waitForReceipt(

--- a/packages/blockchains/evm/src/index.ts
+++ b/packages/blockchains/evm/src/index.ts
@@ -20,6 +20,7 @@ export function registerEvmSdk(sdk?: TrainSDK, auth?: TrainAuth): void {
 }
 
 export { EvmHTLCPublicClient, EvmHTLCWalletClient } from './client/index.js'
-export type { EvmHTLCPublicClientConfig, EvmHTLCWalletClientConfig, EvmSigner } from './types.js'
+export type { EvmHTLCPublicClientConfig, EvmHTLCWalletClientConfig, EvmSigner, EvmTransactionRequest } from './types.js'
+export type { BuildApproveTxParams } from './client/wallet/buildApproveTx.js'
 export { deriveKeyFromEvmSignature, getEvmTypedData } from './login/index.js'
 export type { Eip1193Provider } from './login/index.js'

--- a/packages/blockchains/evm/src/types.ts
+++ b/packages/blockchains/evm/src/types.ts
@@ -22,6 +22,18 @@ export type EvmWalletSignConfig = {
 }
 
 /**
+ * A built, unsigned EVM transaction request. Output of the builder methods
+ * (`buildUserLockTx`, `buildRefundTx`, `buildRedeemSolverTx`, `buildApproveTx`)
+ * and input shape accepted by `EvmSigner.sendTransaction`.
+ */
+export interface EvmTransactionRequest {
+    to: string
+    data: string
+    value?: bigint
+    chainId?: number
+}
+
+/**
  * Minimal signer interface for EVM write operations.
  * Integrators wrap their library's signer (viem WalletClient, ethers Signer,
  * raw EIP-1193 provider) into this interface.
@@ -34,12 +46,7 @@ export interface EvmSigner {
      * Sign and broadcast a transaction, returning the tx hash.
      * The SDK builds all calldata; the signer only needs to sign and send.
      */
-    sendTransaction(tx: {
-        to: string
-        data: string
-        value?: bigint
-        chainId?: number
-    }): Promise<string>
+    sendTransaction(tx: EvmTransactionRequest): Promise<string>
 }
 
 export type EvmHTLCPublicClientConfig = {

--- a/packages/blockchains/evm/src/types.ts
+++ b/packages/blockchains/evm/src/types.ts
@@ -7,6 +7,9 @@ declare module '@train-protocol/sdk' {
     interface HTLCWalletClientConfigMap {
         eip155: EvmHTLCWalletClientConfig
     }
+    interface HTLCTransactionRequestMap {
+        eip155: EvmTransactionRequest
+    }
 }
 
 declare module '@train-protocol/auth' {

--- a/packages/blockchains/solana/src/client/WalletClient.ts
+++ b/packages/blockchains/solana/src/client/WalletClient.ts
@@ -1,5 +1,5 @@
 import { Program } from '@coral-xyz/anchor'
-import { Connection, PublicKey } from '@solana/web3.js'
+import { Connection, PublicKey, Transaction } from '@solana/web3.js'
 import type {
     IHTLCWalletClient,
     UserLockParams,
@@ -13,6 +13,9 @@ import { SolanaHTLCPublicClient } from './PublicClient.js'
 import { userLock as userLockFn } from './wallet/userLock.js'
 import { refund as refundFn } from './wallet/refund.js'
 import { redeemSolver as redeemSolverFn } from './wallet/redeemSolver.js'
+import { buildUserLockTx as buildUserLockTxFn } from './wallet/buildUserLockTx.js'
+import { buildRefundTx as buildRefundTxFn } from './wallet/buildRefundTx.js'
+import { buildRedeemSolverTx as buildRedeemSolverTxFn } from './wallet/buildRedeemSolverTx.js'
 
 export class SolanaHTLCWalletClient extends SolanaHTLCPublicClient implements IHTLCWalletClient {
     private signer: SolanaSigner
@@ -22,7 +25,6 @@ export class SolanaHTLCWalletClient extends SolanaHTLCPublicClient implements IH
         this.signer = config.signer
     }
 
-    // Override buildProgram to use signer's public key
     protected override buildProgram(contractAddress: string, readerKey?: PublicKey, connection?: Connection): Program {
         return buildProgramHelper(contractAddress, connection ?? this.connection, readerKey ?? new PublicKey(this.signer.publicKey))
     }
@@ -45,5 +47,28 @@ export class SolanaHTLCWalletClient extends SolanaHTLCPublicClient implements IH
         const walletPublicKey = new PublicKey(this.signer.publicKey)
         const program = this.buildProgram(params.contractAddress, walletPublicKey)
         return redeemSolverFn(this.connection, this.signer, params, program)
+    }
+
+    // ── Transaction Builders ──────────────────────────────────────────
+    // Return unsigned, blockhash-attached `Transaction` objects ready to
+    // sign/send. Useful for integrators who want to sign/submit via their
+    // own infrastructure.
+
+    async buildUserLockTx(params: UserLockParams): Promise<Transaction> {
+        const walletPublicKey = new PublicKey(this.signer.publicKey)
+        const program = this.buildProgram(params.atomicContract, walletPublicKey)
+        return buildUserLockTxFn(this.connection, program, walletPublicKey, params)
+    }
+
+    async buildRefundTx(params: RefundParams): Promise<Transaction> {
+        const walletPublicKey = new PublicKey(this.signer.publicKey)
+        const program = this.buildProgram(params.contractAddress, walletPublicKey)
+        return buildRefundTxFn(this.connection, program, walletPublicKey, params)
+    }
+
+    async buildRedeemSolverTx(params: RedeemSolverParams): Promise<Transaction> {
+        const walletPublicKey = new PublicKey(this.signer.publicKey)
+        const program = this.buildProgram(params.contractAddress, walletPublicKey)
+        return buildRedeemSolverTxFn(this.connection, program, walletPublicKey, params)
     }
 }

--- a/packages/blockchains/solana/src/client/wallet/buildRedeemSolverTx.ts
+++ b/packages/blockchains/solana/src/client/wallet/buildRedeemSolverTx.ts
@@ -1,0 +1,88 @@
+import { BN, Program } from '@coral-xyz/anchor'
+import { Connection, PublicKey, Transaction } from '@solana/web3.js'
+import type { RedeemSolverParams } from '@train-protocol/sdk'
+import { NATIVE_SOL_ADDRESS } from '../../constants.js'
+import { encoder, hexToUint8Array, writeBigUInt64LE } from '../../utils.js'
+
+function secretToUint8Array(secret: string | bigint): Uint8Array {
+    if (typeof secret === 'bigint') {
+        return hexToUint8Array(secret.toString(16).padStart(64, '0'))
+    }
+    return hexToUint8Array(secret.replace('0x', ''))
+}
+
+export async function buildRedeemSolverTx(
+    connection: Connection,
+    program: Program,
+    walletPublicKey: PublicKey,
+    params: RedeemSolverParams,
+): Promise<Transaction> {
+    if (!params.contractAddress) throw new Error('No contract address')
+
+    const hashlockBytes = hexToUint8Array(params.id.replace('0x', ''))
+    const hashlockArray = Array.from(hashlockBytes)
+    const secretArray = Array.from(secretToUint8Array(params.secret))
+    const lockIndexNum = params.index ?? 1
+    const lockIndex = new BN(lockIndexNum)
+    const indexBytes = writeBigUInt64LE(BigInt(lockIndexNum))
+
+    const [solverLockPda] = PublicKey.findProgramAddressSync(
+        [encoder.encode('solver_lock'), hashlockBytes, indexBytes],
+        program.programId,
+    )
+
+    const solverLockAccount = await (program.account as any).solverLock.fetch(solverLockPda)
+    const rewardRecipient = new PublicKey(solverLockAccount.rewardRecipient)
+    const sender = new PublicKey(solverLockAccount.sender)
+    const recipient = params.destinationAddress ? new PublicKey(params.destinationAddress) : walletPublicKey
+
+    let tx: Transaction
+
+    const asset = params.destinationAsset
+    if (asset.contract && asset.contract !== NATIVE_SOL_ADDRESS) {
+        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
+        const tokenMint = new PublicKey(asset.contract)
+        const [vault] = PublicKey.findProgramAddressSync(
+            [encoder.encode('solver_vault'), hashlockBytes, indexBytes],
+            program.programId,
+        )
+        const recipientTokenAccount = await getAssociatedTokenAddress(tokenMint, recipient)
+        const rewardRecipientTokenAccount = await getAssociatedTokenAddress(tokenMint, rewardRecipient)
+        const callerTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
+
+        tx = await program.methods
+            .redeemSolverToken(hashlockArray, lockIndex, secretArray)
+            .accounts({
+                caller: walletPublicKey,
+                solverLock: solverLockPda,
+                recipient,
+                rewardRecipient,
+                tokenMint,
+                vault,
+                recipientTokenAccount,
+                rewardRecipientTokenAccount,
+                callerTokenAccount,
+                sender,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            })
+            .transaction()
+    } else {
+        tx = await program.methods
+            .redeemSolverSol(hashlockArray, lockIndex, secretArray)
+            .accounts({
+                caller: walletPublicKey,
+                solverLock: solverLockPda,
+                recipient,
+                rewardRecipient,
+            })
+            .transaction()
+    }
+
+    const blockHash = await connection.getLatestBlockhash()
+    tx.recentBlockhash = blockHash.blockhash
+    tx.lastValidBlockHeight = blockHash.lastValidBlockHeight
+    tx.feePayer = walletPublicKey
+
+    return tx
+}

--- a/packages/blockchains/solana/src/client/wallet/buildRefundTx.ts
+++ b/packages/blockchains/solana/src/client/wallet/buildRefundTx.ts
@@ -1,0 +1,64 @@
+import { Program } from '@coral-xyz/anchor'
+import { Connection, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
+import type { RefundParams } from '@train-protocol/sdk'
+import { NATIVE_SOL_ADDRESS } from '../../constants.js'
+import { encoder, hexToUint8Array } from '../../utils.js'
+
+export async function buildRefundTx(
+    connection: Connection,
+    program: Program,
+    walletPublicKey: PublicKey,
+    params: RefundParams,
+): Promise<Transaction> {
+    if (!params.contractAddress) throw new Error('No contract address')
+
+    const hashlockBytes = hexToUint8Array(params.id.replace('0x', ''))
+    const hashlockArray = Array.from(hashlockBytes)
+
+    const [userLockPda] = PublicKey.findProgramAddressSync(
+        [encoder.encode('user_lock'), hashlockBytes],
+        program.programId,
+    )
+
+    let refundIx: TransactionInstruction
+    if (params.sourceAsset.contract && params.sourceAsset.contract !== NATIVE_SOL_ADDRESS) {
+        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
+        const tokenMint = new PublicKey(params.sourceAsset.contract)
+        const senderTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
+        const [vault] = PublicKey.findProgramAddressSync(
+            [encoder.encode('user_vault'), hashlockBytes],
+            program.programId,
+        )
+
+        refundIx = await program.methods
+            .refundUserToken(hashlockArray)
+            .accounts({
+                caller: walletPublicKey,
+                userLock: userLockPda,
+                sender: walletPublicKey,
+                tokenMint,
+                vault,
+                senderTokenAccount,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            })
+            .instruction()
+    } else {
+        refundIx = await program.methods
+            .refundUserSol(hashlockArray)
+            .accounts({
+                caller: walletPublicKey,
+                userLock: userLockPda,
+                sender: walletPublicKey,
+            })
+            .instruction()
+    }
+
+    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
+    const tx = new Transaction()
+    tx.recentBlockhash = blockhash
+    tx.lastValidBlockHeight = lastValidBlockHeight
+    tx.feePayer = walletPublicKey
+    tx.add(refundIx)
+    return tx
+}

--- a/packages/blockchains/solana/src/client/wallet/buildUserLockTx.ts
+++ b/packages/blockchains/solana/src/client/wallet/buildUserLockTx.ts
@@ -1,0 +1,94 @@
+import { BN, Program } from '@coral-xyz/anchor'
+import { Connection, PublicKey, Transaction } from '@solana/web3.js'
+import type { UserLockParams } from '@train-protocol/sdk'
+import { parseUnits } from '@train-protocol/sdk'
+import { NATIVE_SOL_ADDRESS } from '../../constants.js'
+import { encoder, hexToUint8Array } from '../../utils.js'
+
+export async function buildUserLockTx(
+    connection: Connection,
+    program: Program,
+    walletPublicKey: PublicKey,
+    params: UserLockParams,
+): Promise<Transaction> {
+    if (!params.atomicContract) throw new Error('No contract address')
+    if (!params.srcSolverAddress) throw new Error('No Solver address')
+    if (!params.nonce) throw new Error('No nonce')
+    if (!params.solverData) throw new Error('No solver data')
+
+    const hashlock = hexToUint8Array(params.hashlock.replace('0x', ''))
+    const bnAmount = new BN(parseUnits(params.amount, params.sourceAsset.decimals).toString())
+    const bnDstAmount = new BN(params.destinationAmount)
+    const bnRewardAmount = new BN(params.rewardAmount || '0')
+    const bnTimelockDelta = new BN(params.timelockDelta || 0)
+    const bnRewardTimelockDelta = new BN(params.rewardTimelockDelta || 0)
+    const bnQuoteExpiry = new BN(params.quoteExpiry)
+    const lpPublicKey = new PublicKey(params.srcSolverAddress)
+    const hashlockArray = Array.from(hashlock)
+    const userData = Buffer.from(params.nonce.toString())
+    const solverDataBytes = Buffer.from(params.solverData ?? '')
+
+    const [userLockPda] = PublicKey.findProgramAddressSync(
+        [encoder.encode('user_lock'), hashlock],
+        program.programId,
+    )
+
+    const tx = new Transaction()
+
+    if (params.sourceAsset.contract && params.sourceAsset.contract !== NATIVE_SOL_ADDRESS) {
+        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
+        const tokenMint = new PublicKey(params.sourceAsset.contract)
+        const senderTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
+        const [vault] = PublicKey.findProgramAddressSync(
+            [encoder.encode('user_vault'), hashlock],
+            program.programId,
+        )
+
+        const lockTx = await program.methods
+            .userLockToken(
+                hashlockArray,
+                bnAmount, bnTimelockDelta, bnQuoteExpiry,
+                walletPublicKey, lpPublicKey,
+                params.sourceChain, params.destinationChain, params.destinationAddress,
+                bnDstAmount, params.destinationAsset.contract,
+                bnRewardAmount, params.rewardToken ?? '', params.rewardRecipient ?? '', bnRewardTimelockDelta,
+                userData, solverDataBytes,
+            )
+            .accounts({
+                signer: walletPublicKey,
+                userLock: userLockPda,
+                tokenMint,
+                senderTokenAccount,
+                vault,
+                tokenProgram: TOKEN_PROGRAM_ID,
+            })
+            .transaction()
+
+        tx.add(lockTx)
+    } else {
+        const lockTx = await program.methods
+            .userLockSol(
+                hashlockArray,
+                bnAmount, bnTimelockDelta, bnQuoteExpiry,
+                walletPublicKey, lpPublicKey,
+                params.sourceChain, params.destinationChain, params.destinationAddress,
+                bnDstAmount, params.destinationAsset.contract,
+                bnRewardAmount, params.rewardToken ?? '', params.rewardRecipient ?? '', bnRewardTimelockDelta,
+                userData, solverDataBytes,
+            )
+            .accounts({
+                signer: walletPublicKey,
+                userLock: userLockPda,
+            })
+            .transaction()
+
+        tx.add(lockTx)
+    }
+
+    const blockHash = await connection.getLatestBlockhash()
+    tx.recentBlockhash = blockHash.blockhash
+    tx.lastValidBlockHeight = blockHash.lastValidBlockHeight
+    tx.feePayer = walletPublicKey
+
+    return tx
+}

--- a/packages/blockchains/solana/src/client/wallet/redeemSolver.ts
+++ b/packages/blockchains/solana/src/client/wallet/redeemSolver.ts
@@ -1,16 +1,8 @@
-import { BN, Program } from '@coral-xyz/anchor'
-import { Connection, PublicKey, Transaction } from '@solana/web3.js'
+import { Program } from '@coral-xyz/anchor'
+import { Connection, PublicKey } from '@solana/web3.js'
 import type { RedeemSolverParams } from '@train-protocol/sdk'
-import { NATIVE_SOL_ADDRESS } from '../../constants.js'
 import type { SolanaSigner } from '../../types.js'
-import { encoder, hexToUint8Array, writeBigUInt64LE } from '../../utils.js'
-
-function secretToUint8Array(secret: string | bigint): Uint8Array {
-    if (typeof secret === 'bigint') {
-        return hexToUint8Array(secret.toString(16).padStart(64, '0'))
-    }
-    return hexToUint8Array(secret.replace('0x', ''))
-}
+import { buildRedeemSolverTx } from './buildRedeemSolverTx.js'
 
 export async function redeemSolver(
     connection: Connection,
@@ -18,87 +10,19 @@ export async function redeemSolver(
     params: RedeemSolverParams,
     program: Program,
 ): Promise<string> {
-    if (!params.contractAddress) throw new Error('No contract address')
-
     const walletPublicKey = new PublicKey(signer.publicKey)
-    const hashlockBytes = hexToUint8Array(params.id.replace('0x', ''))
-    const hashlockArray = Array.from(hashlockBytes)
-    const secretArray = Array.from(secretToUint8Array(params.secret))
-    const lockIndexNum = params.index ?? 1
-    const lockIndex = new BN(lockIndexNum)
-
-    const indexBytes = writeBigUInt64LE(BigInt(lockIndexNum))
-
-    const [solverLockPda] = PublicKey.findProgramAddressSync(
-        [encoder.encode("solver_lock"), hashlockBytes, indexBytes],
-        program.programId
-    )
-
-    const solverLockAccount = await (program.account as any).solverLock.fetch(solverLockPda)
-    const rewardRecipient = new PublicKey(solverLockAccount.rewardRecipient)
-    const sender = new PublicKey(solverLockAccount.sender)
-    const recipient = params.destinationAddress ? new PublicKey(params.destinationAddress) : walletPublicKey
-
-    let tx: Transaction
-
-    const asset = params.destinationAsset
-    if (asset.contract && asset.contract !== NATIVE_SOL_ADDRESS) {
-        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
-        const tokenMint = new PublicKey(asset.contract)
-        const [vault] = PublicKey.findProgramAddressSync(
-            [encoder.encode("solver_vault"), hashlockBytes, indexBytes],
-            program.programId
-        )
-        const recipientTokenAccount = await getAssociatedTokenAddress(tokenMint, recipient)
-        const rewardRecipientTokenAccount = await getAssociatedTokenAddress(tokenMint, rewardRecipient)
-        const callerTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
-
-        tx = await program.methods
-            .redeemSolverToken(hashlockArray, lockIndex, secretArray)
-            .accounts({
-                caller: walletPublicKey,
-                solverLock: solverLockPda,
-                recipient,
-                rewardRecipient,
-                tokenMint,
-                vault,
-                recipientTokenAccount,
-                rewardRecipientTokenAccount,
-                callerTokenAccount,
-                sender,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-            })
-            .transaction()
-    } else {
-        tx = await program.methods
-            .redeemSolverSol(hashlockArray, lockIndex, secretArray)
-            .accounts({
-                caller: walletPublicKey,
-                solverLock: solverLockPda,
-                recipient,
-                rewardRecipient,
-            })
-            .transaction()
-    }
-
-    const blockHash = await connection.getLatestBlockhash()
-    tx.recentBlockhash = blockHash.blockhash
-    tx.lastValidBlockHeight = blockHash.lastValidBlockHeight
-    tx.feePayer = walletPublicKey
+    const tx = await buildRedeemSolverTx(connection, program, walletPublicKey, params)
 
     try {
         const signature = await signer.sendTransaction(tx)
-
         const res = await connection.confirmTransaction({
-            blockhash: blockHash.blockhash,
-            lastValidBlockHeight: blockHash.lastValidBlockHeight,
+            blockhash: tx.recentBlockhash!,
+            lastValidBlockHeight: tx.lastValidBlockHeight!,
             signature,
         })
         if (res?.value.err) {
             throw new Error(res.value.err.toString())
         }
-
         return signature
     } catch (error) {
         console.error('Error in redeemSolver:', error)

--- a/packages/blockchains/solana/src/client/wallet/refund.ts
+++ b/packages/blockchains/solana/src/client/wallet/refund.ts
@@ -1,9 +1,8 @@
 import { Program } from '@coral-xyz/anchor'
-import { Connection, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
+import { Connection, PublicKey } from '@solana/web3.js'
 import type { RefundParams } from '@train-protocol/sdk'
-import { NATIVE_SOL_ADDRESS } from '../../constants.js'
 import type { SolanaSigner } from '../../types.js'
-import { encoder, hexToUint8Array } from '../../utils.js'
+import { buildRefundTx } from './buildRefundTx.js'
 
 export async function refund(
     connection: Connection,
@@ -11,66 +10,19 @@ export async function refund(
     params: RefundParams,
     program: Program,
 ): Promise<string> {
-    if (!params.contractAddress) throw new Error('No contract address')
-
     const walletPublicKey = new PublicKey(signer.publicKey)
-    const hashlockBytes = hexToUint8Array(params.id.replace('0x', ''))
-    const hashlockArray = Array.from(hashlockBytes)
-
-    const [userLockPda] = PublicKey.findProgramAddressSync(
-        [encoder.encode("user_lock"), hashlockBytes],
-        program.programId
-    )
-
-    let refundIx: TransactionInstruction
-    if (params.sourceAsset.contract && params.sourceAsset.contract !== NATIVE_SOL_ADDRESS) {
-        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
-        const tokenMint = new PublicKey(params.sourceAsset.contract)
-        const senderTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
-        const [vault] = PublicKey.findProgramAddressSync(
-            [encoder.encode("user_vault"), hashlockBytes],
-            program.programId
-        )
-
-        refundIx = await program.methods
-            .refundUserToken(hashlockArray)
-            .accounts({
-                caller: walletPublicKey,
-                userLock: userLockPda,
-                sender: walletPublicKey,
-                tokenMint,
-                vault,
-                senderTokenAccount,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-            })
-            .instruction()
-    } else {
-        refundIx = await program.methods
-            .refundUserSol(hashlockArray)
-            .accounts({
-                caller: walletPublicKey,
-                userLock: userLockPda,
-                sender: walletPublicKey,
-            })
-            .instruction()
-    }
-
-    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
-    const tx = new Transaction()
-    tx.recentBlockhash = blockhash
-    tx.lastValidBlockHeight = lastValidBlockHeight
-    tx.feePayer = walletPublicKey
-    tx.add(refundIx)
+    const tx = await buildRefundTx(connection, program, walletPublicKey, params)
 
     try {
         const signature = await signer.sendTransaction(tx)
-
-        const res = await connection.confirmTransaction({ blockhash, lastValidBlockHeight, signature })
+        const res = await connection.confirmTransaction({
+            blockhash: tx.recentBlockhash!,
+            lastValidBlockHeight: tx.lastValidBlockHeight!,
+            signature,
+        })
         if (res?.value.err) {
             throw new Error(res.value.err.toString())
         }
-
         return signature
     } catch (error: any) {
         console.error('[SolanaHTLC] refund failed', error?.message ?? error, error?.logs ?? [])

--- a/packages/blockchains/solana/src/client/wallet/userLock.ts
+++ b/packages/blockchains/solana/src/client/wallet/userLock.ts
@@ -1,10 +1,9 @@
-import { BN, Program } from '@coral-xyz/anchor'
-import { Connection, PublicKey, Transaction } from '@solana/web3.js'
+import { Program } from '@coral-xyz/anchor'
+import { Connection } from '@solana/web3.js'
 import type { UserLockParams, AtomicResult } from '@train-protocol/sdk'
-import { parseUnits } from '@train-protocol/sdk'
-import { NATIVE_SOL_ADDRESS } from '../../constants.js'
 import type { SolanaSigner } from '../../types.js'
-import { encoder, hexToUint8Array } from '../../utils.js'
+import { buildUserLockTx } from './buildUserLockTx.js'
+import { PublicKey } from '@solana/web3.js'
 
 export async function userLock(
     connection: Connection,
@@ -12,87 +11,8 @@ export async function userLock(
     params: UserLockParams,
     program: Program,
 ): Promise<AtomicResult> {
-    if (!params.atomicContract) throw new Error('No contract address')
-
     const walletPublicKey = new PublicKey(signer.publicKey)
-
-    if (!params.srcSolverAddress) throw new Error("No LP address")
-    if (!params.nonce) throw new Error("No nonce")
-    if (!params.solverData) throw new Error("No solver data")
-
-    const hashlock = hexToUint8Array(params.hashlock.replace('0x', ''))
-    const bnAmount = new BN(parseUnits(params.amount, params.sourceAsset.decimals).toString())
-    const bnDstAmount = new BN(params.destinationAmount)
-    const bnRewardAmount = new BN(params.rewardAmount || '0')
-    const bnTimelockDelta = new BN(params.timelockDelta || 0)
-    const bnRewardTimelockDelta = new BN(params.rewardTimelockDelta || 0)
-    const bnQuoteExpiry = new BN(params.quoteExpiry)
-    const lpPublicKey = new PublicKey(params.srcSolverAddress)
-    const hashlockArray = Array.from(hashlock)
-    const userData = Buffer.from(params.nonce.toString())
-    const solverDataBytes = Buffer.from(params.solverData ?? '')
-
-    const [userLockPda] = PublicKey.findProgramAddressSync(
-        [encoder.encode("user_lock"), hashlock],
-        program.programId
-    )
-
-    const tx = new Transaction()
-
-    if (params.sourceAsset.contract && params.sourceAsset.contract !== NATIVE_SOL_ADDRESS) {
-        const { getAssociatedTokenAddress, TOKEN_PROGRAM_ID } = await import('@solana/spl-token')
-        const tokenMint = new PublicKey(params.sourceAsset.contract)
-        const senderTokenAccount = await getAssociatedTokenAddress(tokenMint, walletPublicKey)
-        const [vault] = PublicKey.findProgramAddressSync(
-            [encoder.encode("user_vault"), hashlock],
-            program.programId
-        )
-
-        const lockTx = await program.methods
-            .userLockToken(
-                hashlockArray,
-                bnAmount, bnTimelockDelta, bnQuoteExpiry,
-                walletPublicKey, lpPublicKey,
-                params.sourceChain, params.destinationChain, params.destinationAddress,
-                bnDstAmount, params.destinationAsset.contract,
-                bnRewardAmount, params.rewardToken ?? '', params.rewardRecipient ?? '', bnRewardTimelockDelta,
-                userData, solverDataBytes
-            )
-            .accounts({
-                signer: walletPublicKey,
-                userLock: userLockPda,
-                tokenMint,
-                senderTokenAccount,
-                vault,
-                tokenProgram: TOKEN_PROGRAM_ID,
-            })
-            .transaction()
-
-        tx.add(lockTx)
-    } else {
-        const lockTx = await program.methods
-            .userLockSol(
-                hashlockArray,
-                bnAmount, bnTimelockDelta, bnQuoteExpiry,
-                walletPublicKey, lpPublicKey,
-                params.sourceChain, params.destinationChain, params.destinationAddress,
-                bnDstAmount, params.destinationAsset.contract,
-                bnRewardAmount, params.rewardToken ?? '', params.rewardRecipient ?? '', bnRewardTimelockDelta,
-                userData, solverDataBytes
-            )
-            .accounts({
-                signer: walletPublicKey,
-                userLock: userLockPda,
-            })
-            .transaction()
-
-        tx.add(lockTx)
-    }
-
-    const blockHash = await connection.getLatestBlockhash()
-    tx.recentBlockhash = blockHash.blockhash
-    tx.lastValidBlockHeight = blockHash.lastValidBlockHeight
-    tx.feePayer = walletPublicKey
+    const tx = await buildUserLockTx(connection, program, walletPublicKey, params)
 
     let signature: string
     try {
@@ -103,8 +23,8 @@ export async function userLock(
     }
 
     const res = await connection.confirmTransaction({
-        blockhash: blockHash.blockhash,
-        lastValidBlockHeight: blockHash.lastValidBlockHeight,
+        blockhash: tx.recentBlockhash!,
+        lastValidBlockHeight: tx.lastValidBlockHeight!,
         signature,
     })
 

--- a/packages/blockchains/solana/src/types.ts
+++ b/packages/blockchains/solana/src/types.ts
@@ -9,6 +9,9 @@ declare module '@train-protocol/sdk' {
     interface HTLCWalletClientConfigMap {
         solana: SolanaHTLCWalletClientConfig
     }
+    interface HTLCTransactionRequestMap {
+        solana: Transaction
+    }
 }
 
 declare module '@train-protocol/auth' {

--- a/packages/blockchains/starknet/src/client/WalletClient.ts
+++ b/packages/blockchains/starknet/src/client/WalletClient.ts
@@ -5,11 +5,19 @@ import type {
     RedeemSolverParams,
     AtomicResult,
 } from '@train-protocol/sdk'
-import type { StarknetHTLCWalletClientConfig, StarknetSigner } from '../types.js'
+import type {
+    StarknetHTLCWalletClientConfig,
+    StarknetSigner,
+    StarknetTransactionRequest,
+} from '../types.js'
 import { StarknetHTLCPublicClient } from './PublicClient.js'
 import { userLock } from './wallet/userLock.js'
 import { refund } from './wallet/refund.js'
 import { redeemSolver } from './wallet/redeemSolver.js'
+import { buildUserLockTx } from './wallet/buildUserLockTx.js'
+import { buildRefundTx } from './wallet/buildRefundTx.js'
+import { buildRedeemSolverTx } from './wallet/buildRedeemSolverTx.js'
+import { buildApproveTx, type BuildApproveTxParams } from './wallet/buildApproveTx.js'
 
 export class StarknetHTLCWalletClient extends StarknetHTLCPublicClient implements IHTLCWalletClient {
     private signer: StarknetSigner
@@ -29,5 +37,23 @@ export class StarknetHTLCWalletClient extends StarknetHTLCPublicClient implement
 
     async redeemSolver(params: RedeemSolverParams): Promise<string> {
         return redeemSolver(this.signer, params)
+    }
+
+    // ── Transaction Builders ──────────────────────────────────────────
+
+    buildUserLockTx(params: UserLockParams): StarknetTransactionRequest {
+        return buildUserLockTx(params)
+    }
+
+    buildRefundTx(params: RefundParams): StarknetTransactionRequest {
+        return buildRefundTx(params)
+    }
+
+    buildRedeemSolverTx(params: RedeemSolverParams): StarknetTransactionRequest {
+        return buildRedeemSolverTx(params)
+    }
+
+    buildApproveTx(params: BuildApproveTxParams): StarknetTransactionRequest {
+        return buildApproveTx(params)
     }
 }

--- a/packages/blockchains/starknet/src/client/wallet/buildApproveTx.ts
+++ b/packages/blockchains/starknet/src/client/wallet/buildApproveTx.ts
@@ -1,0 +1,16 @@
+import { cairo, CallData } from 'starknet'
+import type { StarknetTransactionRequest } from '../../types.js'
+
+export interface BuildApproveTxParams {
+    token: string
+    spender: string
+    amount: bigint
+}
+
+export function buildApproveTx(params: BuildApproveTxParams): StarknetTransactionRequest {
+    return {
+        contractAddress: params.token,
+        entrypoint: 'approve',
+        calldata: CallData.compile([params.spender, cairo.uint256(params.amount)]),
+    }
+}

--- a/packages/blockchains/starknet/src/client/wallet/buildRedeemSolverTx.ts
+++ b/packages/blockchains/starknet/src/client/wallet/buildRedeemSolverTx.ts
@@ -1,0 +1,15 @@
+import { cairo, CallData } from 'starknet'
+import type { RedeemSolverParams } from '@train-protocol/sdk'
+import type { StarknetTransactionRequest } from '../../types.js'
+
+export function buildRedeemSolverTx(params: RedeemSolverParams): StarknetTransactionRequest {
+    return {
+        contractAddress: params.contractAddress,
+        entrypoint: 'redeem_solver',
+        calldata: CallData.compile([
+            cairo.uint256(BigInt(params.id)),
+            cairo.uint256(BigInt(params.index ?? 1)),
+            cairo.uint256(BigInt(params.secret)),
+        ]),
+    }
+}

--- a/packages/blockchains/starknet/src/client/wallet/buildRefundTx.ts
+++ b/packages/blockchains/starknet/src/client/wallet/buildRefundTx.ts
@@ -1,0 +1,11 @@
+import { cairo, CallData } from 'starknet'
+import type { RefundParams } from '@train-protocol/sdk'
+import type { StarknetTransactionRequest } from '../../types.js'
+
+export function buildRefundTx(params: RefundParams): StarknetTransactionRequest {
+    return {
+        contractAddress: params.contractAddress,
+        entrypoint: 'refund_user',
+        calldata: CallData.compile([cairo.uint256(BigInt(params.id))]),
+    }
+}

--- a/packages/blockchains/starknet/src/client/wallet/buildUserLockTx.ts
+++ b/packages/blockchains/starknet/src/client/wallet/buildUserLockTx.ts
@@ -1,0 +1,39 @@
+import { cairo, CallData, byteArray } from 'starknet'
+import { parseUnits } from '@train-protocol/sdk'
+import type { UserLockParams } from '@train-protocol/sdk'
+import type { StarknetTransactionRequest } from '../../types.js'
+import { ZERO_ADDRESS } from '../../constants.js'
+
+export function buildUserLockTx(params: UserLockParams): StarknetTransactionRequest {
+    const parsedAmount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
+    const tokenAddress = params.sourceAsset.contract || ZERO_ADDRESS
+
+    return {
+        contractAddress: params.atomicContract,
+        entrypoint: 'user_lock',
+        calldata: CallData.compile([
+            {
+                hashlock: cairo.uint256(BigInt(params.hashlock)),
+                amount: cairo.uint256(parsedAmount),
+                reward_amount: cairo.uint256(params.rewardAmount ? BigInt(params.rewardAmount) : 0n),
+                timelock_delta: params.timelockDelta,
+                reward_timelock_delta: params.rewardTimelockDelta,
+                quote_expiry: params.quoteExpiry,
+                sender: params.sourceAddress,
+                recipient: params.srcSolverAddress,
+                token: tokenAddress,
+                reward_token: byteArray.byteArrayFromString(params.rewardToken ?? ''),
+                reward_recipient: byteArray.byteArrayFromString(params.rewardRecipient ?? ''),
+                src_chain: byteArray.byteArrayFromString(params.sourceChain || ''),
+            },
+            {
+                dst_chain: byteArray.byteArrayFromString(params.destinationChain),
+                dst_address: byteArray.byteArrayFromString(params.destinationAddress),
+                dst_amount: cairo.uint256(BigInt(params.destinationAmount)),
+                dst_token: byteArray.byteArrayFromString(params.destinationAsset.contract),
+            },
+            byteArray.byteArrayFromString(String(params.nonce)),
+            byteArray.byteArrayFromString(params.solverData || ''),
+        ]),
+    }
+}

--- a/packages/blockchains/starknet/src/client/wallet/redeemSolver.ts
+++ b/packages/blockchains/starknet/src/client/wallet/redeemSolver.ts
@@ -1,24 +1,17 @@
-import { cairo } from 'starknet'
 import type { RedeemSolverParams } from '@train-protocol/sdk'
 import type { StarknetSigner } from '../../types.js'
-import { createContract } from '../helpers.js'
+import { buildRedeemSolverTx } from './buildRedeemSolverTx.js'
 
 export async function redeemSolver(
     signer: StarknetSigner,
     params: RedeemSolverParams,
 ): Promise<string> {
-    const { id, contractAddress, secret, index } = params
-
-    const contract = createContract(contractAddress, signer.account)
+    const call = buildRedeemSolverTx(params)
 
     try {
-        const resp = await contract.invoke('redeem_solver', [
-            cairo.uint256(BigInt(id)),
-            cairo.uint256(BigInt(index ?? 1)),
-            cairo.uint256(BigInt(secret)),
-        ])
-        await signer.account.waitForTransaction(resp.transaction_hash)
-        return resp.transaction_hash
+        const { transaction_hash } = await signer.account.execute([call])
+        await signer.account.waitForTransaction(transaction_hash)
+        return transaction_hash
     } catch (error) {
         console.error('Error in redeemSolver:', error)
         throw error

--- a/packages/blockchains/starknet/src/client/wallet/refund.ts
+++ b/packages/blockchains/starknet/src/client/wallet/refund.ts
@@ -1,20 +1,17 @@
-import { cairo } from 'starknet'
 import type { RefundParams } from '@train-protocol/sdk'
 import type { StarknetSigner } from '../../types.js'
-import { createContract } from '../helpers.js'
+import { buildRefundTx } from './buildRefundTx.js'
 
 export async function refund(
     signer: StarknetSigner,
     params: RefundParams,
 ): Promise<string> {
-    const { id, contractAddress } = params
-
-    const contract = createContract(contractAddress, signer.account)
+    const call = buildRefundTx(params)
 
     try {
-        const resp = await contract.invoke('refund_user', [cairo.uint256(BigInt(id))])
-        await signer.account.waitForTransaction(resp.transaction_hash)
-        return resp.transaction_hash
+        const { transaction_hash } = await signer.account.execute([call])
+        await signer.account.waitForTransaction(transaction_hash)
+        return transaction_hash
     } catch (error) {
         console.error('Error in refund:', error)
         throw error

--- a/packages/blockchains/starknet/src/client/wallet/userLock.ts
+++ b/packages/blockchains/starknet/src/client/wallet/userLock.ts
@@ -1,8 +1,8 @@
-import { cairo, CallData, Contract, byteArray, type Call } from 'starknet'
 import { parseUnits } from '@train-protocol/sdk'
 import type { UserLockParams, AtomicResult } from '@train-protocol/sdk'
 import type { StarknetSigner } from '../../types.js'
-import { ERC20_ABI } from '../../abis/ERC20.js'
+import { buildUserLockTx } from './buildUserLockTx.js'
+import { buildApproveTx } from './buildApproveTx.js'
 import { ZERO_ADDRESS } from '../../constants.js'
 
 export async function userLock(
@@ -12,42 +12,15 @@ export async function userLock(
     const parsedAmount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
     const tokenAddress = params.sourceAsset.contract || ZERO_ADDRESS
 
-    // ERC20 approval
-    const erc20 = new Contract({ abi: ERC20_ABI, address: tokenAddress, providerOrAccount: signer.account })
-    const approveCall: Call = erc20.populate("approve", [params.atomicContract, cairo.uint256(parsedAmount)])
-
-    // Build user_lock call
-    const userLockCall: Call = {
-        contractAddress: params.atomicContract,
-        entrypoint: 'user_lock',
-        calldata: CallData.compile([
-            {
-                hashlock: cairo.uint256(BigInt(params.hashlock)),
-                amount: cairo.uint256(parsedAmount),
-                reward_amount: cairo.uint256(params.rewardAmount ? BigInt(params.rewardAmount) : 0n),
-                timelock_delta: params.timelockDelta,
-                reward_timelock_delta: params.rewardTimelockDelta,
-                quote_expiry: params.quoteExpiry,
-                sender: params.sourceAddress,
-                recipient: params.srcSolverAddress,
-                token: tokenAddress,
-                reward_token: byteArray.byteArrayFromString(params.rewardToken ?? ''),
-                reward_recipient: byteArray.byteArrayFromString(params.rewardRecipient ?? ''),
-                src_chain: byteArray.byteArrayFromString(params.sourceChain || ''),
-            },
-            {
-                dst_chain: byteArray.byteArrayFromString(params.destinationChain),
-                dst_address: byteArray.byteArrayFromString(params.destinationAddress),
-                dst_amount: cairo.uint256(BigInt(params.destinationAmount)),
-                dst_token: byteArray.byteArrayFromString(params.destinationAsset.contract),
-            },
-            byteArray.byteArrayFromString(String(params.nonce)),  // userData — nonce timestamp for recovery
-            byteArray.byteArrayFromString(params.solverData || ''),
-        ]),
-    }
+    const approveCall = buildApproveTx({
+        token: tokenAddress,
+        spender: params.atomicContract,
+        amount: parsedAmount,
+    })
+    const lockCall = buildUserLockTx(params)
 
     try {
-        const { transaction_hash } = await signer.account.execute([approveCall, userLockCall])
+        const { transaction_hash } = await signer.account.execute([approveCall, lockCall])
         await signer.account.waitForTransaction(transaction_hash)
 
         return { hash: transaction_hash, hashlock: params.hashlock, nonce: params.nonce }

--- a/packages/blockchains/starknet/src/index.ts
+++ b/packages/blockchains/starknet/src/index.ts
@@ -4,7 +4,8 @@ import { StarknetHTLCPublicClient, StarknetHTLCWalletClient } from './client/ind
 import { deriveKeyFromStarknetWallet } from './login/index.js'
 
 export { StarknetHTLCPublicClient, StarknetHTLCWalletClient } from './client/index.js'
-export type { StarknetHTLCPublicClientConfig, StarknetHTLCWalletClientConfig, StarknetSigner } from './types.js'
+export type { StarknetHTLCPublicClientConfig, StarknetHTLCWalletClientConfig, StarknetSigner, StarknetTransactionRequest } from './types.js'
+export type { BuildApproveTxParams } from './client/wallet/buildApproveTx.js'
 export { formatStarknetAddress } from './utils.js'
 export { deriveKeyFromStarknetWallet } from './login/index.js'
 export type { StarknetAccountLike } from './login/index.js'

--- a/packages/blockchains/starknet/src/types.ts
+++ b/packages/blockchains/starknet/src/types.ts
@@ -1,5 +1,12 @@
-import type { AccountInterface } from 'starknet'
+import type { AccountInterface, Call } from 'starknet'
 import type { StarknetAccountLike } from './login/wallet-sign.js'
+
+/**
+ * A built Starknet contract call. Output of the builder methods —
+ * a single `Call` for `refund`/`redeemSolver`/`approve`, or an array
+ * for `userLock` (when chained with an approve in a multicall).
+ */
+export type StarknetTransactionRequest = Call
 
 declare module '@train-protocol/sdk' {
     interface HTLCPublicClientConfigMap {

--- a/packages/blockchains/starknet/src/types.ts
+++ b/packages/blockchains/starknet/src/types.ts
@@ -15,6 +15,9 @@ declare module '@train-protocol/sdk' {
     interface HTLCWalletClientConfigMap {
         starknet: StarknetHTLCWalletClientConfig
     }
+    interface HTLCTransactionRequestMap {
+        starknet: StarknetTransactionRequest
+    }
 }
 
 declare module '@train-protocol/auth' {

--- a/packages/blockchains/tron/src/client/PublicClient.ts
+++ b/packages/blockchains/tron/src/client/PublicClient.ts
@@ -14,6 +14,7 @@ import { getUserLockDetails } from './public/getUserLockDetails.js'
 import { getSolverLockDetails } from './public/getSolverLockDetails.js'
 import { recoverSwap } from './public/recoverSwap.js'
 import { getTransaction } from './public/getTransaction.js'
+import { getTrc20Allowance } from './public/getTrc20Allowance.js'
 
 export class TronHTLCPublicClient extends HTLCPublicClient {
     protected rpc: TronRpcClient
@@ -39,5 +40,9 @@ export class TronHTLCPublicClient extends HTLCPublicClient {
 
     async getTransaction(txHash: string): Promise<TransactionInfo | null> {
         return getTransaction(this.rpc, txHash)
+    }
+
+    async getTrc20Allowance(token: string, owner: string, spender: string): Promise<bigint> {
+        return getTrc20Allowance(this.rpc, token, owner, spender)
     }
 }

--- a/packages/blockchains/tron/src/client/WalletClient.ts
+++ b/packages/blockchains/tron/src/client/WalletClient.ts
@@ -5,11 +5,15 @@ import type {
     RedeemSolverParams,
     AtomicResult,
 } from '@train-protocol/sdk'
-import type { TronHTLCWalletClientConfig, TronSigner } from '../types.js'
+import type { TronHTLCWalletClientConfig, TronSigner, TronTransactionRequest } from '../types.js'
 import { TronHTLCPublicClient } from './PublicClient.js'
 import { userLock } from './wallet/userLock.js'
 import { refund } from './wallet/refund.js'
 import { redeemSolver } from './wallet/redeemSolver.js'
+import { buildUserLockTx } from './wallet/buildUserLockTx.js'
+import { buildRefundTx } from './wallet/buildRefundTx.js'
+import { buildRedeemSolverTx } from './wallet/buildRedeemSolverTx.js'
+import { buildApproveTx, type BuildApproveTxParams } from './wallet/buildApproveTx.js'
 
 export class TronHTLCWalletClient extends TronHTLCPublicClient implements IHTLCWalletClient {
     private signer: TronSigner
@@ -29,5 +33,23 @@ export class TronHTLCWalletClient extends TronHTLCPublicClient implements IHTLCW
 
     async redeemSolver(params: RedeemSolverParams): Promise<string> {
         return redeemSolver(this.rpc, this.signer, params)
+    }
+
+    // ── Transaction Builders ──────────────────────────────────────────
+
+    buildUserLockTx(params: UserLockParams): TronTransactionRequest {
+        return buildUserLockTx(params)
+    }
+
+    buildRefundTx(params: RefundParams): TronTransactionRequest {
+        return buildRefundTx(params)
+    }
+
+    buildRedeemSolverTx(params: RedeemSolverParams): TronTransactionRequest {
+        return buildRedeemSolverTx(params)
+    }
+
+    buildApproveTx(params: BuildApproveTxParams): TronTransactionRequest {
+        return buildApproveTx(params)
     }
 }

--- a/packages/blockchains/tron/src/client/public/getTrc20Allowance.ts
+++ b/packages/blockchains/tron/src/client/public/getTrc20Allowance.ts
@@ -1,0 +1,25 @@
+import { AbiFunction } from 'ox'
+import { trc20Functions } from '../../abi.js'
+import type { TronRpcClient } from '../../rpc.js'
+import { FUNCTION_SIGNATURES } from '../../constants.js'
+import { toEvmHex, toTronHex } from '../../address.js'
+import { encodeParams, hex } from '../../utils.js'
+
+export async function getTrc20Allowance(
+    rpc: TronRpcClient,
+    token: string,
+    owner: string,
+    spender: string,
+): Promise<bigint> {
+    const calldata = AbiFunction.encodeData(trc20Functions.allowance, [
+        toEvmHex(owner),
+        toEvmHex(spender),
+    ])
+    const raw = await rpc.triggerConstantContract(
+        toTronHex(token),
+        FUNCTION_SIGNATURES.allowance,
+        encodeParams(calldata),
+        toTronHex(owner),
+    )
+    return AbiFunction.decodeResult(trc20Functions.allowance, hex('0x' + raw))
+}

--- a/packages/blockchains/tron/src/client/wallet/buildApproveTx.ts
+++ b/packages/blockchains/tron/src/client/wallet/buildApproveTx.ts
@@ -1,0 +1,26 @@
+import { AbiFunction } from 'ox'
+import { trc20Functions } from '../../abi.js'
+import type { TronTransactionRequest } from '../../types.js'
+import { DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
+import { toEvmHex, toTronHex } from '../../address.js'
+import { encodeParams } from '../../utils.js'
+
+export interface BuildApproveTxParams {
+    token: string
+    spender: string
+    amount: bigint
+}
+
+export function buildApproveTx(params: BuildApproveTxParams): TronTransactionRequest {
+    const calldata = AbiFunction.encodeData(trc20Functions.approve, [
+        toEvmHex(params.spender),
+        params.amount,
+    ])
+    return {
+        contractAddress: toTronHex(params.token),
+        functionSelector: FUNCTION_SIGNATURES.approve,
+        parameter: encodeParams(calldata),
+        callValue: 0,
+        feeLimit: DEFAULT_FEE_LIMIT,
+    }
+}

--- a/packages/blockchains/tron/src/client/wallet/buildRedeemSolverTx.ts
+++ b/packages/blockchains/tron/src/client/wallet/buildRedeemSolverTx.ts
@@ -1,0 +1,22 @@
+import { AbiFunction } from 'ox'
+import type { RedeemSolverParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { TronTransactionRequest } from '../../types.js'
+import { DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
+import { toTronHex } from '../../address.js'
+import { encodeParams, hex } from '../../utils.js'
+
+export function buildRedeemSolverTx(params: RedeemSolverParams): TronTransactionRequest {
+    const calldata = AbiFunction.encodeData(htlcFunctions.redeemSolver, [
+        hex(params.id),
+        1n,
+        BigInt(params.secret),
+    ])
+    return {
+        contractAddress: toTronHex(params.contractAddress),
+        functionSelector: FUNCTION_SIGNATURES.redeemSolver,
+        parameter: encodeParams(calldata),
+        callValue: 0,
+        feeLimit: DEFAULT_FEE_LIMIT,
+    }
+}

--- a/packages/blockchains/tron/src/client/wallet/buildRefundTx.ts
+++ b/packages/blockchains/tron/src/client/wallet/buildRefundTx.ts
@@ -1,0 +1,18 @@
+import { AbiFunction } from 'ox'
+import type { RefundParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { TronTransactionRequest } from '../../types.js'
+import { DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
+import { toTronHex } from '../../address.js'
+import { encodeParams, hex } from '../../utils.js'
+
+export function buildRefundTx(params: RefundParams): TronTransactionRequest {
+    const calldata = AbiFunction.encodeData(htlcFunctions.refundUser, [hex(params.id)])
+    return {
+        contractAddress: toTronHex(params.contractAddress),
+        functionSelector: FUNCTION_SIGNATURES.refundUser,
+        parameter: encodeParams(calldata),
+        callValue: 0,
+        feeLimit: DEFAULT_FEE_LIMIT,
+    }
+}

--- a/packages/blockchains/tron/src/client/wallet/buildUserLockTx.ts
+++ b/packages/blockchains/tron/src/client/wallet/buildUserLockTx.ts
@@ -1,0 +1,50 @@
+import { AbiFunction } from 'ox'
+import { parseUnits, toHex32 } from '@train-protocol/sdk'
+import type { UserLockParams } from '@train-protocol/sdk'
+import { htlcFunctions } from '../../abi.js'
+import type { TronTransactionRequest } from '../../types.js'
+import { ZERO_ADDRESS, DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
+import { toEvmHex, toTronHex } from '../../address.js'
+import { encodeParams, hex } from '../../utils.js'
+
+export function buildUserLockTx(params: UserLockParams): TronTransactionRequest {
+    const { sourceAsset } = params
+
+    const parsedAmount = parseUnits(params.amount.toString(), sourceAsset.decimals)
+    const tokenAddress = sourceAsset.contract || ZERO_ADDRESS
+    const isNativeToken = !sourceAsset.contract || sourceAsset.contract === ZERO_ADDRESS
+
+    const userData = toHex32(BigInt(params.nonce))
+    const calldata = AbiFunction.encodeData(htlcFunctions.userLock, [
+        {
+            hashlock: hex(params.hashlock),
+            amount: parsedAmount,
+            rewardAmount: params.rewardAmount || 0n,
+            timelockDelta: params.timelockDelta,
+            rewardTimelockDelta: params.rewardTimelockDelta ?? 0,
+            quoteExpiry: params.quoteExpiry,
+            sender: toEvmHex(params.sourceAddress),
+            recipient: toEvmHex(params.srcSolverAddress),
+            token: toEvmHex(tokenAddress),
+            rewardToken: params.rewardToken ? toEvmHex(params.rewardToken) : hex(ZERO_ADDRESS),
+            rewardRecipient: params.rewardRecipient ? toEvmHex(params.rewardRecipient) : hex(ZERO_ADDRESS),
+            srcChain: params.sourceChain || '',
+        },
+        {
+            dstChain: params.destinationChain,
+            dstAddress: params.destinationAddress,
+            dstAmount: params.destinationAmount,
+            dstToken: params.destinationAsset.contract,
+        },
+        hex(userData),
+        hex(params.solverData || '0x'),
+    ])
+
+    return {
+        contractAddress: toTronHex(params.atomicContract),
+        functionSelector: FUNCTION_SIGNATURES.userLock,
+        parameter: encodeParams(calldata),
+        callValue: isNativeToken ? Number(parsedAmount) : 0,
+        feeLimit: DEFAULT_FEE_LIMIT,
+    }
+}

--- a/packages/blockchains/tron/src/client/wallet/redeemSolver.ts
+++ b/packages/blockchains/tron/src/client/wallet/redeemSolver.ts
@@ -1,37 +1,29 @@
-import { AbiFunction } from 'ox'
 import type { RedeemSolverParams } from '@train-protocol/sdk'
-import { htlcFunctions } from '../../abi.js'
 import type { TronRpcClient } from '../../rpc.js'
 import type { TronSigner } from '../../types.js'
-import { DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
 import { toTronHex } from '../../address.js'
-import { decodeContractError, encodeParams, hex } from '../../utils.js'
+import { decodeContractError } from '../../utils.js'
+import { buildRedeemSolverTx } from './buildRedeemSolverTx.js'
 
 export async function redeemSolver(
     rpc: TronRpcClient,
     signer: TronSigner,
     params: RedeemSolverParams,
 ): Promise<string> {
-    const { id, contractAddress, secret, destinationAddress } = params
-
-    const caller = destinationAddress ?? signer.address
+    const req = buildRedeemSolverTx(params)
+    const caller = params.destinationAddress ?? signer.address
     const ownerHex = toTronHex(caller)
-    const contractHex = toTronHex(contractAddress)
-
-    const calldata = AbiFunction.encodeData(htlcFunctions.redeemSolver, [
-        hex(id),
-        1n,
-        BigInt(secret),
-    ])
-    const parameter = encodeParams(calldata)
 
     try {
-        await rpc.triggerConstantContract(contractHex, FUNCTION_SIGNATURES.redeemSolver, parameter, ownerHex)
-
+        await rpc.triggerConstantContract(req.contractAddress, req.functionSelector, req.parameter, ownerHex)
         const unsignedTx = await rpc.triggerSmartContract(
-            contractHex, FUNCTION_SIGNATURES.redeemSolver, parameter, ownerHex, 0, DEFAULT_FEE_LIMIT,
+            req.contractAddress,
+            req.functionSelector,
+            req.parameter,
+            ownerHex,
+            req.callValue ?? 0,
+            req.feeLimit ?? 0,
         )
-
         return signer.signAndBroadcast(unsignedTx)
     } catch (error) {
         const errorName = decodeContractError(error)

--- a/packages/blockchains/tron/src/client/wallet/refund.ts
+++ b/packages/blockchains/tron/src/client/wallet/refund.ts
@@ -1,32 +1,28 @@
-import { AbiFunction } from 'ox'
 import type { RefundParams } from '@train-protocol/sdk'
-import { htlcFunctions } from '../../abi.js'
 import type { TronRpcClient } from '../../rpc.js'
 import type { TronSigner } from '../../types.js'
-import { DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
 import { toTronHex } from '../../address.js'
-import { decodeContractError, encodeParams, hex } from '../../utils.js'
+import { decodeContractError } from '../../utils.js'
+import { buildRefundTx } from './buildRefundTx.js'
 
 export async function refund(
     rpc: TronRpcClient,
     signer: TronSigner,
     params: RefundParams,
 ): Promise<string> {
-    const { id, contractAddress } = params
-
+    const req = buildRefundTx(params)
     const ownerHex = toTronHex(signer.address)
-    const contractHex = toTronHex(contractAddress)
-
-    const calldata = AbiFunction.encodeData(htlcFunctions.refundUser, [hex(id)])
-    const parameter = encodeParams(calldata)
 
     try {
-        await rpc.triggerConstantContract(contractHex, FUNCTION_SIGNATURES.refundUser, parameter, ownerHex)
-
+        await rpc.triggerConstantContract(req.contractAddress, req.functionSelector, req.parameter, ownerHex)
         const unsignedTx = await rpc.triggerSmartContract(
-            contractHex, FUNCTION_SIGNATURES.refundUser, parameter, ownerHex, 0, DEFAULT_FEE_LIMIT,
+            req.contractAddress,
+            req.functionSelector,
+            req.parameter,
+            ownerHex,
+            req.callValue ?? 0,
+            req.feeLimit ?? 0,
         )
-
         return signer.signAndBroadcast(unsignedTx)
     } catch (error) {
         const errorName = decodeContractError(error)

--- a/packages/blockchains/tron/src/client/wallet/userLock.ts
+++ b/packages/blockchains/tron/src/client/wallet/userLock.ts
@@ -1,81 +1,45 @@
-import { AbiFunction } from 'ox'
-import { parseUnits, toHex32 } from '@train-protocol/sdk'
+import { parseUnits } from '@train-protocol/sdk'
 import type { UserLockParams, AtomicResult } from '@train-protocol/sdk'
-import { htlcFunctions, trc20Functions } from '../../abi.js'
 import type { TronRpcClient } from '../../rpc.js'
-import type { TronSigner } from '../../types.js'
-import { ZERO_ADDRESS, DEFAULT_FEE_LIMIT, FUNCTION_SIGNATURES } from '../../constants.js'
-import { toEvmHex, toTronHex } from '../../address.js'
-import { decodeContractError, encodeParams, hex } from '../../utils.js'
+import type { TronSigner, TronTransactionRequest } from '../../types.js'
+import { ZERO_ADDRESS } from '../../constants.js'
+import { toTronHex } from '../../address.js'
+import { decodeContractError } from '../../utils.js'
+import { buildUserLockTx } from './buildUserLockTx.js'
+import { buildApproveTx } from './buildApproveTx.js'
+import { getTrc20Allowance } from '../public/getTrc20Allowance.js'
 
 export async function userLock(
     rpc: TronRpcClient,
     signer: TronSigner,
     params: UserLockParams,
 ): Promise<AtomicResult> {
-    const { sourceAsset, sourceAddress } = params
-
-    const parsedAmount = parseUnits(params.amount.toString(), sourceAsset.decimals)
-    const tokenAddress = sourceAsset.contract || ZERO_ADDRESS
-    const isNativeToken = !sourceAsset.contract || sourceAsset.contract === ZERO_ADDRESS
-
-    const ownerHex = toTronHex(sourceAddress)
-    const contractHex = toTronHex(params.atomicContract)
+    const tokenAddress = params.sourceAsset.contract
+    const isNativeToken = !tokenAddress || tokenAddress === ZERO_ADDRESS
+    const parsedAmount = parseUnits(params.amount.toString(), params.sourceAsset.decimals)
 
     if (!isNativeToken) {
-        await ensureTRC20Allowance(
+        const allowance = await getTrc20Allowance(
             rpc,
-            signer,
-            tokenAddress,
-            sourceAddress,
+            tokenAddress!,
+            params.sourceAddress,
             params.atomicContract,
-            parsedAmount,
         )
+        if (allowance < parsedAmount) {
+            const approveTx = buildApproveTx({
+                token: tokenAddress!,
+                spender: params.atomicContract,
+                amount: parsedAmount,
+            })
+            const approveTxId = await sendRequest(rpc, signer, approveTx, params.sourceAddress)
+            await waitForConfirmation(rpc, approveTxId)
+        }
     }
 
-    const userData = toHex32(BigInt(params.nonce))
-    const calldata = AbiFunction.encodeData(htlcFunctions.userLock, [
-        {
-            hashlock: hex(params.hashlock),
-            amount: parsedAmount,
-            rewardAmount: params.rewardAmount || 0n,
-            timelockDelta: params.timelockDelta,
-            rewardTimelockDelta: params.rewardTimelockDelta ?? 0,
-            quoteExpiry: params.quoteExpiry,
-            sender: toEvmHex(params.sourceAddress),
-            recipient: toEvmHex(params.srcSolverAddress),
-            token: toEvmHex(tokenAddress),
-            rewardToken: params.rewardToken ? toEvmHex(params.rewardToken) : hex(ZERO_ADDRESS),
-            rewardRecipient: params.rewardRecipient ? toEvmHex(params.rewardRecipient) : hex(ZERO_ADDRESS),
-            srcChain: params.sourceChain || '',
-        },
-        {
-            dstChain: params.destinationChain,
-            dstAddress: params.destinationAddress,
-            dstAmount: params.destinationAmount,
-            dstToken: params.destinationAsset.contract,
-        },
-        hex(userData),
-        hex(params.solverData || '0x'),
-    ])
-
-    const parameter = encodeParams(calldata)
+    const lockTx = buildUserLockTx(params)
 
     try {
-        // Simulate first
-        await rpc.triggerConstantContract(contractHex, FUNCTION_SIGNATURES.userLock, parameter, ownerHex)
-
-        // Build and sign
-        const unsignedTx = await rpc.triggerSmartContract(
-            contractHex,
-            FUNCTION_SIGNATURES.userLock,
-            parameter,
-            ownerHex,
-            isNativeToken ? Number(parsedAmount) : 0,
-            DEFAULT_FEE_LIMIT,
-        )
-
-        const hash = await signer.signAndBroadcast(unsignedTx)
+        const hash = await sendRequest(rpc, signer, lockTx, params.sourceAddress)
         return { hash, hashlock: params.hashlock, nonce: params.nonce }
     } catch (error) {
         const errorName = decodeContractError(error)
@@ -85,37 +49,23 @@ export async function userLock(
     }
 }
 
-async function ensureTRC20Allowance(
+async function sendRequest(
     rpc: TronRpcClient,
     signer: TronSigner,
-    tokenAddress: string,
+    req: TronTransactionRequest,
     owner: string,
-    spender: string,
-    requiredAmount: bigint,
-): Promise<void> {
-    const tokenHex = toTronHex(tokenAddress)
+): Promise<string> {
     const ownerHex = toTronHex(owner)
-
-    const allowanceCalldata = AbiFunction.encodeData(trc20Functions.allowance, [
-        toEvmHex(owner),
-        toEvmHex(spender),
-    ])
-    const aParam = encodeParams(allowanceCalldata)
-    const allowanceRaw = await rpc.triggerConstantContract(tokenHex, FUNCTION_SIGNATURES.allowance, aParam, ownerHex)
-    const allowance = AbiFunction.decodeResult(trc20Functions.allowance, hex('0x' + allowanceRaw))
-
-    if (allowance >= requiredAmount) return
-
-    const approveCalldata = AbiFunction.encodeData(trc20Functions.approve, [
-        toEvmHex(spender),
-        requiredAmount,
-    ])
-    const apParam = encodeParams(approveCalldata)
+    await rpc.triggerConstantContract(req.contractAddress, req.functionSelector, req.parameter, ownerHex)
     const unsignedTx = await rpc.triggerSmartContract(
-        tokenHex, FUNCTION_SIGNATURES.approve, apParam, ownerHex, 0, DEFAULT_FEE_LIMIT,
+        req.contractAddress,
+        req.functionSelector,
+        req.parameter,
+        ownerHex,
+        req.callValue ?? 0,
+        req.feeLimit ?? 0,
     )
-    const txId = await signer.signAndBroadcast(unsignedTx)
-    await waitForConfirmation(rpc, txId)
+    return signer.signAndBroadcast(unsignedTx)
 }
 
 async function waitForConfirmation(

--- a/packages/blockchains/tron/src/index.ts
+++ b/packages/blockchains/tron/src/index.ts
@@ -20,6 +20,7 @@ export function registerTronSdk(sdk?: TrainSDK, auth?: TrainAuth): void {
 }
 
 export { TronHTLCPublicClient, TronHTLCWalletClient } from './client/index.js'
-export type { TronHTLCPublicClientConfig, TronHTLCWalletClientConfig, TronSigner, TronUnsignedTransaction, TronWalletSignConfig } from './types.js'
+export type { TronHTLCPublicClientConfig, TronHTLCWalletClientConfig, TronSigner, TronTransactionRequest, TronUnsignedTransaction, TronWalletSignConfig } from './types.js'
+export type { BuildApproveTxParams } from './client/wallet/buildApproveTx.js'
 export { deriveKeyFromTronWallet } from './login/index.js'
 export type { TronWalletLike } from './login/index.js'

--- a/packages/blockchains/tron/src/types.ts
+++ b/packages/blockchains/tron/src/types.ts
@@ -7,6 +7,9 @@ declare module '@train-protocol/sdk' {
     interface HTLCWalletClientConfigMap {
         tron: TronHTLCWalletClientConfig
     }
+    interface HTLCTransactionRequestMap {
+        tron: TronTransactionRequest
+    }
 }
 
 declare module '@train-protocol/auth' {

--- a/packages/blockchains/tron/src/types.ts
+++ b/packages/blockchains/tron/src/types.ts
@@ -20,6 +20,24 @@ export type TronWalletSignConfig = {
 }
 
 /**
+ * A built, unsigned Tron transaction request — the calldata payload that the
+ * SDK passes to TronGrid's `triggersmartcontract` endpoint to produce a
+ * `TronUnsignedTransaction`. Output of the builder methods.
+ */
+export interface TronTransactionRequest {
+    /** Contract address in Tron hex form (41-prefixed) */
+    contractAddress: string
+    /** Function signature, e.g. "userLock(...)" */
+    functionSelector: string
+    /** Hex-encoded ABI parameters (no 0x prefix) */
+    parameter: string
+    /** Native TRX value to send in sun (for native lock); defaults to 0 */
+    callValue?: number
+    /** Fee limit override; defaults to DEFAULT_FEE_LIMIT */
+    feeLimit?: number
+}
+
+/**
  * Minimal signer interface for Tron write operations.
  * The SDK builds unsigned transactions via TronGrid API,
  * then the signer signs and broadcasts them.

--- a/packages/sdk/src/registry.ts
+++ b/packages/sdk/src/registry.ts
@@ -1,4 +1,4 @@
-import type { IHTLCPublicClient, IHTLCWalletClient } from './types/htlc-client'
+import type { IHTLCPublicClient, IHTLCWalletClient, TransactionRequestFor } from './types/htlc-client'
 import { RegistrationError } from './errors'
 
 // --- HTLC Client Registry ---
@@ -51,7 +51,7 @@ export class TrainSDK {
 
     registerHTLCWalletClient<N extends string>(
         chainNamespace: N,
-        factory: (config: WalletConfigFor<N>) => IHTLCWalletClient,
+        factory: (config: WalletConfigFor<N>) => IHTLCWalletClient<TransactionRequestFor<N>>,
     ): void {
         this.walletRegistry.set(chainNamespace, factory)
     }
@@ -73,7 +73,7 @@ export class TrainSDK {
     createHTLCWalletClient<N extends string>(
         chainNamespace: N,
         config: WalletConfigFor<N>,
-    ): IHTLCWalletClient {
+    ): IHTLCWalletClient<TransactionRequestFor<N>> {
         const factory = this.walletRegistry.get(chainNamespace)
         if (!factory) {
             throw new RegistrationError(
@@ -81,7 +81,7 @@ export class TrainSDK {
                 `Did you forget to call the corresponding register function (e.g. registerEvmSdk())?`
             )
         }
-        return factory(config)
+        return factory(config) as IHTLCWalletClient<TransactionRequestFor<N>>
     }
 
     getRegisteredNamespaces(): string[] {
@@ -104,7 +104,7 @@ export function registerHTLCPublicClient<N extends string>(
 
 export function registerHTLCWalletClient<N extends string>(
     chainNamespace: N,
-    factory: (config: WalletConfigFor<N>) => IHTLCWalletClient,
+    factory: (config: WalletConfigFor<N>) => IHTLCWalletClient<TransactionRequestFor<N>>,
 ): void {
     return defaultTrainSDK.registerHTLCWalletClient(chainNamespace, factory)
 }
@@ -119,7 +119,7 @@ export function createHTLCPublicClient<N extends string>(
 export function createHTLCWalletClient<N extends string>(
     chainNamespace: N,
     config: WalletConfigFor<N>,
-): IHTLCWalletClient {
+): IHTLCWalletClient<TransactionRequestFor<N>> {
     return defaultTrainSDK.createHTLCWalletClient(chainNamespace, config)
 }
 

--- a/packages/sdk/src/types/htlc-client.ts
+++ b/packages/sdk/src/types/htlc-client.ts
@@ -11,10 +11,51 @@ export interface IHTLCPublicClient {
     getTransaction(txHash: string): Promise<TransactionInfo | null>
 }
 
-export interface IHTLCWalletClient extends IHTLCPublicClient {
+/**
+ * Open registry of chain-specific unsigned transaction request types.
+ * Chain SDKs augment this via declaration merging:
+ *
+ *   declare module '@train-protocol/sdk' {
+ *       interface HTLCTransactionRequestMap {
+ *           eip155: EvmTransactionRequest
+ *       }
+ *   }
+ *
+ * Consumers can then reference the chain's request shape via
+ * `TransactionRequestFor<'eip155'>` without importing from the chain package.
+ */
+export interface HTLCTransactionRequestMap {}
+
+export type TransactionRequestFor<N extends string> = N extends keyof HTLCTransactionRequestMap
+    ? HTLCTransactionRequestMap[N]
+    : unknown
+
+/**
+ * Parameters accepted by `buildApproveTx` on chains with ERC20-style allowances
+ * (EVM, Tron, Starknet). Chains without an allowance model (Solana, Aztec) do
+ * not implement `buildApproveTx`.
+ */
+export interface BuildApproveTxParams {
+    token: string
+    spender: string
+    amount: bigint
+}
+
+export interface IHTLCWalletClient<TTx = unknown> extends IHTLCPublicClient {
     userLock(params: UserLockParams): Promise<AtomicResult>
     refund(params: RefundParams): Promise<string>
     redeemSolver(params: RedeemSolverParams): Promise<string>
+    /**
+     * Builders return the chain's natural unsigned-transaction shape. Some chains
+     * are sync (EVM/Tron/Starknet), some async (Solana/Aztec); Aztec's user-lock
+     * builder returns an array (authwit + lock batch). The interface accepts all
+     * shapes; concrete classes narrow.
+     */
+    buildUserLockTx(params: UserLockParams): TTx | TTx[] | Promise<TTx | TTx[]>
+    buildRefundTx(params: RefundParams): TTx | Promise<TTx>
+    buildRedeemSolverTx(params: RedeemSolverParams): TTx | Promise<TTx>
+    /** Present only on chains with ERC20-style allowances. */
+    buildApproveTx?(params: BuildApproveTxParams): TTx | Promise<TTx>
 }
 
 export abstract class HTLCPublicClient implements IHTLCPublicClient {


### PR DESCRIPTION
Expose pure `build{Method}Tx` builders alongside the existing `userLock` / `refund` / `redeemSolver` executors so integrators can construct unsigned transactions and sign/submit them via their own infrastructure (Safe SDK, smart accounts, custom relayers).

Each chain gets a `{Chain}TransactionRequest` type matching its natural unsigned-transaction unit, plus `buildApproveTx` / `get{Erc,Trc}20Allowance` where the chain has allowance semantics. Executors are refactored as thin orchestrators that consume the builders.