### PR TITLE
fix(swap): gate recovery on chain SDK readiness

### DIFF
--- a/apps/app/app/providers.tsx
+++ b/apps/app/app/providers.tsx
@@ -38,7 +38,9 @@ if (typeof window !== "undefined") {
     sdkReady.set("solana",   import("@train-protocol/solana").then(m => m.registerSolanaSdk()))
     sdkReady.set("starknet", import("@train-protocol/starknet").then(m => m.registerStarknetSdk()))
     sdkReady.set("tron",     import("@train-protocol/tron").then(m => m.registerTronSdk()))
-    sdkReady.forEach(p => p.catch(() => {}))
+    sdkReady.forEach((p, ns) =>
+        p.catch(e => console.error(`SDK registration failed: ${ns}`, e))
+    )
 }
 
 export const waitForSdk = (namespace: string): Promise<void> =>

--- a/apps/app/app/providers.tsx
+++ b/apps/app/app/providers.tsx
@@ -30,13 +30,19 @@ import AppSettings from "@/lib/AppSettings"
 import { useRpcConfigStore } from "@/stores/rpcConfigStore"
 import Loading from "@/components/Loading"
 
+const sdkReady = new Map<string, Promise<void>>()
+
 if (typeof window !== "undefined") {
-    registerEvmSdk()
-    import("@train-protocol/aztec").then(m => m.registerAztecSdk())
-    import("@train-protocol/solana").then(m => m.registerSolanaSdk())
-    import("@train-protocol/starknet").then(m => m.registerStarknetSdk())
-    import("@train-protocol/tron").then(m => m.registerTronSdk())
+    sdkReady.set("eip155",   Promise.resolve(registerEvmSdk()))
+    sdkReady.set("aztec",    import("@train-protocol/aztec").then(m => m.registerAztecSdk()))
+    sdkReady.set("solana",   import("@train-protocol/solana").then(m => m.registerSolanaSdk()))
+    sdkReady.set("starknet", import("@train-protocol/starknet").then(m => m.registerStarknetSdk()))
+    sdkReady.set("tron",     import("@train-protocol/tron").then(m => m.registerTronSdk()))
+    sdkReady.forEach(p => p.catch(() => {}))
 }
+
+export const waitForSdk = (namespace: string): Promise<void> =>
+    sdkReady.get(namespace) ?? Promise.resolve()
 
 const INTERCOM_APP_ID = "h5zisg78"
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
@@ -112,6 +118,7 @@ function AppShell({ children, settings }: { children: React.ReactNode; settings:
                 <TrainProvider
                     baseUrl={AppSettings.TrainApiUri ?? ''}
                     resolveNodeUrls={resolveNodeUrls}
+                    sdkReady={waitForSdk}
                     initialNetworks={settings.networks}
                     secretDerivation={{ persist: true }}
                 >

--- a/apps/app/app/swap/page.tsx
+++ b/apps/app/app/swap/page.tsx
@@ -27,10 +27,7 @@ export default function SwapPage() {
         recoveryAttemptedRef.current = key;
         recover(txHash, sourceNetwork)
             .then(setActiveHashlock)
-            .catch(e => {
-                recoveryAttemptedRef.current = null;
-                console.error("Auto-recovery failed:", e);
-            });
+            .catch(e => console.error("Auto-recovery failed:", e));
     }, [sourceNetwork, txHash, activeHashlock, recover, setActiveHashlock]);
 
     useSwapProgress(activeHashlock);

--- a/apps/app/app/swap/page.tsx
+++ b/apps/app/app/swap/page.tsx
@@ -27,7 +27,10 @@ export default function SwapPage() {
         recoveryAttemptedRef.current = key;
         recover(txHash, sourceNetwork)
             .then(setActiveHashlock)
-            .catch(e => console.error("Auto-recovery failed:", e));
+            .catch(e => {
+                recoveryAttemptedRef.current = null;
+                console.error("Auto-recovery failed:", e);
+            });
     }, [sourceNetwork, txHash, activeHashlock, recover, setActiveHashlock]);
 
     useSwapProgress(activeHashlock);

--- a/apps/app/components/Swap/AtomicChat/AtomicContent/TimelineStep.tsx
+++ b/apps/app/components/Swap/AtomicChat/AtomicContent/TimelineStep.tsx
@@ -56,7 +56,7 @@ const TxLink = ({ txLink }: { txLink: string }) => {
 function TimelineStep({ step, isLastStep }: { step: TimelineStepType, isLastStep: boolean }) {
     return (
         <li className={clsx(isLastStep ? '' : 'pb-5', 'relative')}>
-            <div className="flex items-center justify-between w-full">
+            <div className="flex items-center justify-between w-full gap-2">
                 {!isLastStep && (
                     <div className={clsx(`absolute top-1/2 left-4 -ml-px mt-2.5 h-[30%] w-0.5 `, {
                         "bg-primary/20": step.status !== StepStatus.Complete && step.status !== StepStatus.Failed,
@@ -64,7 +64,7 @@ function TimelineStep({ step, isLastStep }: { step: TimelineStepType, isLastStep
                     })}
                         aria-hidden="true" />
                 )}
-                <div className={clsx(`group relative flex `, {
+                <div className={clsx(`group relative flex min-w-0 flex-1`, {
                     "items-start": step?.description,
                     "items-center": !step?.description
                 })}>
@@ -81,7 +81,7 @@ function TimelineStep({ step, isLastStep }: { step: TimelineStepType, isLastStep
                         </span>
                         {
                             step?.description &&
-                            <span className="text-sm text-secondary-text">{step?.description}</span>
+                            <span className="text-sm text-secondary-text break-all">{step?.description}</span>
                         }
                     </span>
                 </div>

--- a/packages/react/src/hooks/useRecoverSwap.ts
+++ b/packages/react/src/hooks/useRecoverSwap.ts
@@ -6,7 +6,7 @@ import { useStoreContext } from '../providers/TrainProvider'
 import { useNetworksContext } from '../providers/NetworksProvider'
 import { TrainError, TrainErrorCode } from '../types'
 import type { SwapData } from '../types'
-import { caip2Id } from '../internal/branded'
+import { caip2Id, parseCaip2Id } from '../internal/branded'
 
 export interface UseRecoverSwapResult {
     /** Recover a swap from a transaction hash. Returns the hashlock. */
@@ -55,6 +55,12 @@ export function useRecoverSwap(): UseRecoverSwapResult {
             // Not found locally — recover from chain
             const srcNetwork = networkMap.get(sourceNetwork)
             if (!srcNetwork) throw new Error(`Network not found: ${networkId}`)
+
+            // Wait for the chain SDK to be registered (handles apps that
+            // dynamically import chain packages — see TrainConfig.sdkReady).
+            if (config.sdkReady) {
+                await config.sdkReady(parseCaip2Id(sourceNetwork).namespace)
+            }
 
             const client = walletCtx.createClient(sourceNetwork)
             const details = await client.recoverSwap(txHash, srcNetwork)

--- a/packages/react/src/providers/TrainProvider.tsx
+++ b/packages/react/src/providers/TrainProvider.tsx
@@ -108,6 +108,7 @@ export function TrainProvider({
             baseUrl: config.baseUrl,
             onError: config.onError,
             resolveNodeUrls: config.resolveNodeUrls,
+            sdkReady: config.sdkReady,
             persistSwaps: config.persistSwaps,
             storage: config.storage,
             sdk: config.sdk,
@@ -117,7 +118,7 @@ export function TrainProvider({
             initialPrices: config.initialPrices,
             secretDerivation: config.secretDerivation,
         }),
-        [config.baseUrl, config.onError, config.resolveNodeUrls, config.persistSwaps, config.storage, config.sdk, config.auth, config.queryClient, config.initialNetworks, config.initialPrices, config.secretDerivation],
+        [config.baseUrl, config.onError, config.resolveNodeUrls, config.sdkReady, config.persistSwaps, config.storage, config.sdk, config.auth, config.queryClient, config.initialNetworks, config.initialPrices, config.secretDerivation],
     )
 
     const trainValue = useMemo(

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -21,6 +21,15 @@ export interface TrainConfig {
     auth?: TrainAuth
     /** Resolve RPC node URLs for a CAIP-2 network ID (used for solver lock verification) */
     resolveNodeUrls?: (networkId: string) => string[]
+    /**
+     * Wait for a chain SDK to be registered for the given namespace.
+     * If your app registers chain SDKs via dynamic imports, return a promise
+     * that resolves once `registerXxxSdk()` has run. Hooks that need to create
+     * a client (e.g. `useRecoverSwap`) will await this before calling into the
+     * SDK, preventing races on first render. Return `Promise.resolve()` for
+     * already-registered namespaces.
+     */
+    sdkReady?: (namespace: string) => Promise<void>
     /** Optional TanStack Query client (for sharing with app-level QueryClientProvider) */
     queryClient?: QueryClient
     /** Pre-fetched networks (e.g. from SSR) to seed the cache and avoid a duplicate client-side fetch */


### PR DESCRIPTION
Adds optional TrainConfig.sdkReady so useRecoverSwap awaits the source chain's dynamic-import registration before calling createClient. Fixes RegistrationError when navigating directly to /swap?... for a non-EVM source on a cold cache.